### PR TITLE
fix: align detection/playbook/policy schemas with actual YAML structure

### DIFF
--- a/tools/soac-harness/schemas/detection.schema.json
+++ b/tools/soac-harness/schemas/detection.schema.json
@@ -2,67 +2,90 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://soacframe.io/schemas/detection.schema.json",
   "title": "SOaC Detection Rule v1",
-  "description": "JSON Schema for detection.yaml files — SOaC apiVersion soac.io/v1",
+  "description": "JSON Schema for detection.yaml \u2014 soac.io/v1 DetectionRule",
   "type": "object",
-  "required": ["apiVersion", "kind", "metadata", "spec"],
+  "required": [
+    "apiVersion",
+    "kind",
+    "metadata",
+    "spec"
+  ],
   "properties": {
     "apiVersion": {
       "type": "string",
-      "const": "soac.io/v1",
-      "description": "Must be soac.io/v1"
+      "const": "soac.io/v1"
     },
     "kind": {
       "type": "string",
-      "const": "Detection",
-      "description": "Must be Detection"
+      "const": "DetectionRule"
     },
     "metadata": {
       "type": "object",
-      "required": ["name"],
+      "required": [
+        "name"
+      ],
       "properties": {
-        "name": { "type": "string", "minLength": 1 },
-        "namespace": { "type": "string" },
-        "labels": { "type": "object" },
-        "annotations": { "type": "object" }
-      }
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "version": {
+          "type": "string"
+        },
+        "author": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string"
+        },
+        "package_id": {
+          "type": "string"
+        },
+        "mitre_attack": {
+          "type": "array"
+        },
+        "severity": {
+          "type": "string"
+        },
+        "confidence": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": true
     },
     "spec": {
       "type": "object",
-      "required": ["rules"],
+      "required": [
+        "description"
+      ],
       "properties": {
-        "severity": {
-          "type": "string",
-          "enum": ["CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO"]
-        },
-        "mitre": {
-          "type": "array",
-          "items": { "type": "string" }
-        },
-        "platforms": {
-          "type": "array",
-          "items": { "type": "string" }
+        "description": {
+          "type": "string"
         },
         "data_sources": {
-          "type": "array",
-          "items": { "type": "string" }
+          "type": "array"
         },
-        "rules": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": ["name"],
-            "properties": {
-              "name": { "type": "string" },
-              "description": { "type": "string" },
-              "query": { "type": "string" },
-              "platform": { "type": "string" },
-              "severity": { "type": "string" }
-            }
-          },
-          "minItems": 1
+        "logic": {
+          "type": "object"
+        },
+        "tuning": {
+          "type": "object"
+        },
+        "response": {
+          "type": "object"
+        },
+        "test_cases": {
+          "type": "array"
         }
-      }
+      },
+      "additionalProperties": true
     }
   },
-  "additionalProperties": false
+  "additionalProperties": true
 }

--- a/tools/soac-harness/schemas/playbook.schema.json
+++ b/tools/soac-harness/schemas/playbook.schema.json
@@ -2,78 +2,111 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://soacframe.io/schemas/playbook.schema.json",
   "title": "CLAW Playbook v1",
-  "description": "JSON Schema for playbook.yaml files — CLAW apiVersion claw.soac.io/v1",
+  "description": "JSON Schema for playbook.yaml \u2014 claw.soac.io/v1 Playbook",
   "type": "object",
-  "required": ["apiVersion", "kind", "metadata", "spec"],
+  "required": [
+    "apiVersion",
+    "kind",
+    "metadata",
+    "spec"
+  ],
   "properties": {
     "apiVersion": {
       "type": "string",
-      "const": "claw.soac.io/v1",
-      "description": "Must be claw.soac.io/v1"
+      "const": "claw.soac.io/v1"
     },
     "kind": {
       "type": "string",
-      "const": "Playbook",
-      "description": "Must be Playbook"
+      "const": "Playbook"
     },
     "metadata": {
       "type": "object",
-      "required": ["name"],
+      "required": [
+        "name"
+      ],
       "properties": {
-        "name": { "type": "string", "minLength": 1 },
-        "namespace": { "type": "string" },
-        "labels": { "type": "object" },
-        "annotations": { "type": "object" }
-      }
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "version": {
+          "type": "string"
+        },
+        "author": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "array"
+        },
+        "mitre_attack": {
+          "type": "array"
+        },
+        "severity": {
+          "type": "string"
+        },
+        "package_id": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true
     },
     "spec": {
       "type": "object",
-      "required": ["trigger", "steps"],
+      "required": [
+        "trigger",
+        "steps"
+      ],
       "properties": {
-        "severity": {
-          "type": "string",
-          "enum": ["CRITICAL", "HIGH", "MEDIUM", "LOW"]
-        },
-        "mitre": {
-          "type": "array",
-          "items": { "type": "string" }
+        "description": {
+          "type": "string"
         },
         "trigger": {
           "type": "object",
-          "required": ["source"],
+          "required": [
+            "source"
+          ],
           "properties": {
-            "source": { "type": "string" },
-            "conditions": {
-              "type": "array",
-              "items": { "type": "object" }
+            "source": {
+              "type": "string"
             },
-            "cooldown": { "type": "string" }
-          }
+            "conditions": {
+              "type": "array"
+            },
+            "cooldown": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": true
+        },
+        "inputs": {
+          "type": "array"
         },
         "steps": {
           "type": "array",
           "items": {
             "type": "object",
-            "required": ["action"],
-            "properties": {
-              "action": { "type": "string" },
-              "target": { "type": "string" },
-              "params": { "type": "object" },
-              "description": { "type": "string" },
-              "timeout": { "type": "string" },
-              "retry": { "type": "object" },
-              "on_failure": { "type": "string" }
-            }
+            "required": [
+              "action"
+            ],
+            "additionalProperties": true
           },
           "minItems": 1
         },
-        "rollback": {
-          "type": "array",
-          "items": { "type": "object" }
+        "outputs": {
+          "type": "object"
         },
-        "governance": { "type": "object" }
-      }
+        "rollback": {
+          "type": "array"
+        },
+        "governance": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": true
     }
   },
-  "additionalProperties": false
+  "additionalProperties": true
 }

--- a/tools/soac-harness/schemas/policy.schema.json
+++ b/tools/soac-harness/schemas/policy.schema.json
@@ -2,48 +2,93 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://soacframe.io/schemas/policy.schema.json",
   "title": "SOaC Policy v1",
-  "description": "JSON Schema for policy.yaml files — SOaC apiVersion soac.io/v1",
+  "description": "JSON Schema for policy.yaml \u2014 soac.io/v1 Policy",
   "type": "object",
-  "required": ["apiVersion", "kind", "metadata", "spec"],
+  "required": [
+    "apiVersion",
+    "kind",
+    "metadata",
+    "spec"
+  ],
   "properties": {
     "apiVersion": {
       "type": "string",
-      "const": "soac.io/v1",
-      "description": "Must be soac.io/v1"
+      "const": "soac.io/v1"
     },
     "kind": {
       "type": "string",
-      "const": "Policy",
-      "description": "Must be Policy"
+      "const": "Policy"
     },
     "metadata": {
       "type": "object",
-      "required": ["name"],
+      "required": [
+        "name"
+      ],
       "properties": {
-        "name": { "type": "string", "minLength": 1 },
-        "namespace": { "type": "string" },
-        "labels": { "type": "object" },
-        "annotations": { "type": "object" }
-      }
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "version": {
+          "type": "string"
+        },
+        "author": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string"
+        },
+        "package_id": {
+          "type": "string"
+        },
+        "scope": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": true
     },
     "spec": {
       "type": "object",
-      "required": ["environments"],
+      "required": [
+        "environments"
+      ],
       "properties": {
-        "severity": { "type": "string" },
-        "scope": { "type": "string" },
-        "environments": {
-          "type": "object",
-          "description": "Environment-specific policy rules (lab, staging, production)",
-          "additionalProperties": {
-            "type": "object"
-          }
+        "description": {
+          "type": "string"
         },
-        "access_control": { "type": "object" },
-        "governance": { "type": "object" },
-        "audit": { "type": "object" }
-      }
+        "environments": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "name"
+            ],
+            "additionalProperties": true
+          },
+          "minItems": 1,
+          "description": "Environment-specific policy rules (array of environment objects)"
+        },
+        "actions": {
+          "type": "object"
+        },
+        "access_control": {
+          "type": "object"
+        },
+        "compliance": {
+          "type": "object"
+        },
+        "audit": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": true
     }
   },
-  "additionalProperties": false
+  "additionalProperties": true
 }


### PR DESCRIPTION
## Summary

Fixes all 3 YAML artifact schemas to match the actual file structure in packages.

## Changes

### detection.schema.json
| Issue | Before | After |
|-------|--------|-------|
| `kind` const | `Detection` | `DetectionRule` |
| `spec.rules` | required | removed (actual uses `spec.logic`) |
| `spec.description` | missing | added |
| `spec.data_sources` | flat string array | array of objects |
| `additionalProperties` | `false` | `true` |

### playbook.schema.json
| Issue | Before | After |
|-------|--------|-------|
| `metadata` fields | only `name` | + `version`, `author`, `mitre_attack`, `severity`, `package_id` |
| `spec.steps` items | strict `{action, params}` | flexible with `additionalProperties: true` |
| `spec.inputs/outputs` | missing | added |
| `additionalProperties` | `false` | `true` |

### policy.schema.json
| Issue | Before | After |
|-------|--------|-------|
| `spec.environments` type | `object` | `array` of environment objects |
| `spec.actions/compliance` | missing | added |
| `additionalProperties` | `false` | `true` |

## Why

The schemas were written against a hypothetical flat format, not the actual Kubernetes-style apiVersion/kind format used in the packages. This caused 100% of detection/playbook/policy validations to fail silently (files existed but never passed validation).
