### PR TITLE
fix: add missing manifest fields to 012_litellm_supply_chain_defense

### DIFF
--- a/packages/012_litellm_supply_chain_defense/manifest.json
+++ b/packages/012_litellm_supply_chain_defense/manifest.json
@@ -6,14 +6,103 @@
   "difficulty": 4,
   "tier": "Elite",
   "category": "Supply Chain",
-  "tags": ["supply-chain", "litellm", "ai", "credential-theft", "defense", "python", "ci-cd"],
+  "tags": [
+    "supply-chain",
+    "litellm",
+    "ai",
+    "credential-theft",
+    "defense",
+    "python",
+    "ci-cd"
+  ],
   "threat_actor": "Shai-Hulud",
   "github_path": "packages/012_litellm_supply_chain_defense",
-  "roles": ["Red Team", "Blue Team", "SOC", "CISO"],
-  "mitre": ["T1195.002", "T1552.001", "T1528", "T1078.004", "T1546.016", "T1071.001", "T1567"],
-  "stacks": ["sentinel", "sigma", "splunk", "wazuh", "crowdstrike"],
+  "roles": [
+    "Red Team",
+    "Blue Team",
+    "SOC",
+    "CISO"
+  ],
+  "mitre": [
+    "T1195.002",
+    "T1552.001",
+    "T1528",
+    "T1078.004",
+    "T1546.016",
+    "T1071.001",
+    "T1567"
+  ],
+  "stacks": [
+    "sentinel",
+    "sigma",
+    "splunk",
+    "wazuh",
+    "crowdstrike"
+  ],
   "created": "2026-03-28",
   "updated": "2026-03-28",
   "license": "Apache-2.0",
-  "author": "SOaC Community"
+  "author": "SOaC Community",
+  "schema_version": "3.0",
+  "mitre_version": "v15.1",
+  "platform_targets": [
+    "python",
+    "litellm_proxy",
+    "pypi",
+    "azure_ad",
+    "aws",
+    "ci_cd"
+  ],
+  "simulation_steps": [
+    {
+      "step_index": 1,
+      "role": "Red Team",
+      "title": "Publish Trojanized LiteLLM Package",
+      "technique": [
+        "T1195.002"
+      ]
+    },
+    {
+      "step_index": 2,
+      "role": "Red Team",
+      "title": "Deploy .pth File Persistence",
+      "technique": [
+        "T1546.016"
+      ]
+    },
+    {
+      "step_index": 3,
+      "role": "Red Team",
+      "title": "Harvest Cloud Credentials from Environment",
+      "technique": [
+        "T1552.001"
+      ]
+    },
+    {
+      "step_index": 4,
+      "role": "Red Team",
+      "title": "Steal OAuth Tokens from Running Sessions",
+      "technique": [
+        "T1528"
+      ]
+    },
+    {
+      "step_index": 5,
+      "role": "Red Team",
+      "title": "Exfiltrate Credentials to C2 Infrastructure",
+      "technique": [
+        "T1567",
+        "T1071.001"
+      ]
+    }
+  ],
+  "saas_targets": [],
+  "lab_scenarios": [
+    {
+      "id": "lab-012-full",
+      "title": "LiteLLM Supply Chain Attack Defense \u2014 Full Simulation",
+      "type": "full",
+      "estimated_minutes": 45
+    }
+  ]
 }


### PR DESCRIPTION
Adds the 4 required Harness v3.0 fields (`schema_version`, `mitre_version`, `platform_targets`, `simulation_steps`) plus optional `saas_targets` and `lab_scenarios`.

All values derived from scenario.json content and pkg-001 reference.