### PR TITLE
chore: upgrade actions/checkout and actions/setup-node to v4

### DIFF
--- a/.github/workflows/soac-validation.yml
+++ b/.github/workflows/soac-validation.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '18'
       - name: Install dependencies


### PR DESCRIPTION
Upgrades `actions/checkout@v3` → `@v4` and `actions/setup-node@v3` → `@v4` in `soac-validation.yml`.

`soac-drift-detection.yml` already uses v4 (created in Session E).

Resolves Node.js 16 deprecation warnings.