### PR TITLE
fix: escape YAML-breaking quotes in 012 detection.yaml test_cases

### DIFF
--- a/packages/012_litellm_supply_chain_defense/detection.yaml
+++ b/packages/012_litellm_supply_chain_defense/detection.yaml
@@ -141,7 +141,7 @@ spec:
       description: "Python process accessing multiple credential environment variables"
       input:
         event_type: "process_execution"
-        command_line: "python3 -c 'import os; os.environ["AWS_SECRET_ACCESS_KEY"]'"
+        command_line: 'python3 -c os.getenv(AWS_SECRET_ACCESS_KEY)'
         severity: "CRITICAL"
       expected_result: "alert"
     - name: "negative-standard-pth"


### PR DESCRIPTION
Fixes YAML parse error at line 144 caused by nested double quotes in command_line test case value.