### PR TITLE
feat: add detection, playbook, policy to 004_rapid_vulnerability_exploit_emergency_patch_defense

### DIFF
--- a/packages/004_rapid_vulnerability_exploit_emergency_patch_defense/detection.yaml
+++ b/packages/004_rapid_vulnerability_exploit_emergency_patch_defense/detection.yaml
@@ -1,0 +1,188 @@
+apiVersion: soac.io/v1
+kind: DetectionRule
+
+metadata:
+  name: "rapid-vulnerability-exploit-detection"
+  version: "1.0.0"
+  author: "SOaC Community"
+  created: "2026-03-28T00:00:00Z"
+  package_id: "pkg-004"
+  mitre_attack:
+    - technique: "T1190"
+      tactic: "Initial Access"
+    - technique: "T1059"
+      tactic: "Execution"
+    - technique: "T1505.003"
+      tactic: "Persistence"
+    - technique: "T1203"
+      tactic: "Execution"
+    - technique: "T1210"
+      tactic: "Lateral Movement"
+  severity: "CRITICAL"
+  confidence: "HIGH"
+  tags: ["pkg-004", "exploit", "cve", "web-shell", "zero-day"]
+
+spec:
+  description: "Detects rapid exploitation of known CVEs against internet-facing assets, web shell deployment, post-exploitation command execution, and lateral movement from compromised perimeter devices."
+
+  data_sources:
+    - name: "Web Application Firewall Logs"
+      type: "waf"
+      fields: ["request.uri", "request.method", "response.status", "source.ip", "rule.id"]
+    - name: "Endpoint Process Logs"
+      type: "edr"
+      fields: ["process.name", "process.command_line", "process.parent", "file.path"]
+    - name: "Network IDS Alerts"
+      type: "nids"
+      fields: ["alert.signature_id", "src_ip", "dst_ip", "dst_port"]
+
+  logic:
+    type: "correlation"
+    timewindow: "10m"
+    implementations:
+      sentinel:
+        kql: |
+          // Detect exploit attempts against known CVEs followed by web shell activity
+          let exploit_attempts = CommonSecurityLog
+          | where DeviceAction has_any ("blocked", "detected", "alert")
+          | where RequestURL matches regex @"(\\.asp|cmd|exec|eval|passthru|shell)"
+              or Activity has_any ("CVE-", "exploit", "injection")
+          | project ExploitTime=TimeGenerated, SourceIP, DestinationIP, RequestURL, Activity;
+          // Detect web shell indicators on IIS/Apache/Nginx servers
+          let webshell_activity = DeviceProcessEvents
+          | where InitiatingProcessFileName in ("w3wp.exe", "httpd", "nginx", "apache2", "php-cgi")
+          | where FileName in ("cmd.exe", "powershell.exe", "bash", "sh", "whoami", "net.exe", "certutil.exe")
+          | project ShellTime=Timestamp, DeviceId, DeviceName, FileName, ProcessCommandLine, InitiatingProcessFileName;
+          // Detect new files in web-accessible directories
+          let webshell_drop = DeviceFileEvents
+          | where FolderPath has_any ("wwwroot", "htdocs", "html", "inetpub", "www")
+          | where FileName endswith_cs ".aspx" or FileName endswith_cs ".jsp" or FileName endswith_cs ".php"
+          | where ActionType == "FileCreated"
+          | project DropTime=Timestamp, DeviceId, DeviceName, FileName, FolderPath;
+          // Correlate exploit attempt with shell spawn or file drop within 10 minutes
+          exploit_attempts
+          | join kind=inner (webshell_activity) on $left.DestinationIP == $right.DeviceName
+          | where abs(datetime_diff('minute', ExploitTime, ShellTime)) <= 10
+          | union (
+              exploit_attempts
+              | join kind=inner (webshell_drop) on $left.DestinationIP == $right.DeviceName
+              | where abs(datetime_diff('minute', ExploitTime, DropTime)) <= 10
+          )
+      sigma:
+        rule: |
+          title: Web Shell Spawned from Web Server Process
+          status: experimental
+          logsource:
+            category: process_creation
+            product: windows
+          detection:
+            selection_parent:
+              ParentImage|endswith:
+                - '\\w3wp.exe'
+                - '\\httpd.exe'
+                - '\\nginx.exe'
+                - '\\php-cgi.exe'
+                - '\\tomcat.exe'
+            selection_child:
+              Image|endswith:
+                - '\\cmd.exe'
+                - '\\powershell.exe'
+                - '\\whoami.exe'
+                - '\\net.exe'
+                - '\\certutil.exe'
+                - '\\bitsadmin.exe'
+            condition: selection_parent and selection_child
+          level: critical
+          tags:
+            - attack.persistence
+            - attack.t1505.003
+            - attack.execution
+            - attack.t1059
+      splunk:
+        spl: |
+          index=endpoint sourcetype=sysmon EventCode=1
+          | where match(ParentImage, "(w3wp|httpd|nginx|apache2|php-cgi|tomcat)")
+          | where match(Image, "(cmd\\.exe|powershell\\.exe|bash|sh|whoami|net\\.exe|certutil)")
+          | eval risk_score=case(
+              match(CommandLine, "(whoami|net user|ipconfig|systeminfo)"), 85,
+              match(CommandLine, "(certutil|bitsadmin|curl|wget)"), 95,
+              match(CommandLine, "(powershell|cmd /c)"), 90,
+              true(), 80)
+          | stats count min(_time) as first_seen max(_time) as last_seen values(CommandLine) as commands by ComputerName ParentImage Image
+          | where count > 0
+          | sort -risk_score
+      crowdstrike:
+        hunt: |
+          // CrowdStrike Falcon LTS: Web shell spawn from web server
+          event_simpleName=ProcessRollup2
+          | ParentBaseFileName IN ("w3wp.exe", "httpd", "nginx", "apache2", "php-cgi", "tomcat")
+          | FileName IN ("cmd.exe", "powershell.exe", "bash", "sh", "whoami", "net.exe", "certutil.exe")
+          | stats count earliest(timestamp) latest(timestamp) values(CommandLine) by aid ParentBaseFileName FileName
+          | where count >= 1
+      wazuh:
+        rule: |
+          <group name="exploit,web-shell,">
+            <rule id="100301" level="14">
+              <if_sid>61603</if_sid>
+              <field name="win.eventdata.parentImage" type="pcre2">w3wp|httpd|nginx|apache2|php-cgi</field>
+              <field name="win.eventdata.image" type="pcre2">cmd\.exe|powershell\.exe|whoami|net\.exe</field>
+              <description>Web shell command execution from web server process [CVE Exploit Chain]</description>
+              <mitre>
+                <id>T1505.003</id>
+                <id>T1059</id>
+                <id>T1190</id>
+              </mitre>
+            </rule>
+            <rule id="100302" level="13">
+              <if_sid>550</if_sid>
+              <field name="file" type="pcre2">\.(aspx|jsp|php)$</field>
+              <field name="file" type="pcre2">wwwroot|htdocs|inetpub|html</field>
+              <description>Suspicious file created in web-accessible directory [Potential Web Shell]</description>
+              <mitre>
+                <id>T1505.003</id>
+                <id>T1190</id>
+              </mitre>
+            </rule>
+            <rule id="100303" level="12">
+              <if_sid>61603</if_sid>
+              <field name="win.eventdata.commandLine" type="pcre2">certutil.*-urlcache|bitsadmin.*transfer</field>
+              <description>LOLBin download activity following web server exploitation</description>
+              <mitre>
+                <id>T1105</id>
+                <id>T1059</id>
+              </mitre>
+            </rule>
+          </group>
+
+  tuning:
+    threshold: 1
+    whitelist: ["health-check.aspx", "diagnostics.php"]
+    noise_reduction: "dedup_by_device_and_parent"
+
+  response:
+    playbook: "emergency-exploit-containment"
+    escalation: "auto"
+    notify: ["soc-team", "vuln-management-team"]
+
+  test_cases:
+    - name: "positive-webshell-spawn"
+      description: "cmd.exe spawned by w3wp.exe should trigger critical alert"
+      input:
+        event_type: "process_creation"
+        parent_image: "w3wp.exe"
+        image: "cmd.exe"
+        severity: "CRITICAL"
+      expected_result: "alert"
+    - name: "positive-file-drop"
+      description: "New .aspx file in wwwroot should trigger alert"
+      input:
+        event_type: "file_creation"
+        file_path: "C:\\inetpub\\wwwroot\\cmd.aspx"
+        severity: "CRITICAL"
+      expected_result: "alert"
+    - name: "negative-legitimate-deploy"
+      description: "Scheduled deployment writing to wwwroot should not trigger"
+      input:
+        event_type: "file_creation"
+        file_path: "C:\\inetpub\\wwwroot\\health-check.aspx"
+      expected_result: "no_alert"

--- a/packages/004_rapid_vulnerability_exploit_emergency_patch_defense/playbook.yaml
+++ b/packages/004_rapid_vulnerability_exploit_emergency_patch_defense/playbook.yaml
@@ -1,0 +1,190 @@
+apiVersion: claw.soac.io/v1
+kind: Playbook
+
+metadata:
+  name: "emergency-exploit-containment"
+  version: "1.0.0"
+  author: "SOaC Community"
+  created: "2026-03-28T00:00:00Z"
+  tags: ["pkg-004", "automated-response", "exploit", "patching"]
+  mitre_attack: ["T1190", "T1059", "T1505.003", "T1203", "T1210"]
+  severity: "CRITICAL"
+  package_id: "pkg-004"
+
+spec:
+  description: "Emergency containment and remediation for active exploitation of known CVEs against internet-facing assets. Isolates compromised hosts, deploys compensating WAF controls, coordinates emergency patching, and validates remediation."
+
+  trigger:
+    source: "BODY"
+    conditions:
+      - field: "detection_type"
+        operator: "in"
+        value: ["exploit_chain_detected", "web_shell_deployed", "cve_exploit_active"]
+    cooldown: "5m"
+
+  inputs:
+    - name: "detection_event"
+      type: "object"
+      required: true
+      description: "The detection event payload from The Body"
+    - name: "target_host"
+      type: "string"
+      required: true
+      description: "The compromised host or asset identifier"
+    - name: "cve_id"
+      type: "string"
+      required: false
+      description: "The CVE identifier being exploited if known"
+
+  steps:
+    - id: "step-1"
+      name: "isolate_compromised_host"
+      action: "containment"
+      target: "EDGE"
+      parameters:
+        endpoint: "/api/v1/hosts/{hostId}/contain"
+        method: "POST"
+        provider: "crowdstrike"
+        containment_level: "network_isolation"
+      timeout: "60s"
+      retry:
+        max_attempts: 3
+        backoff: "exponential"
+      on_failure: "halt"
+    - id: "step-2"
+      name: "assess_blast_radius"
+      action: "enrichment"
+      target: "BODY"
+      parameters:
+        endpoint: "/api/v1/assets/blast-radius"
+        method: "POST"
+        scan_type: "lateral_movement_assessment"
+        include_network_neighbors: true
+      timeout: "120s"
+      retry:
+        max_attempts: 2
+        backoff: "exponential"
+      on_failure: "continue"
+    - id: "step-3"
+      name: "deploy_compensating_waf_rules"
+      action: "remediation"
+      target: "EDGE"
+      parameters:
+        endpoint: "/enforce"
+        method: "POST"
+        action_type: "virtual_patch"
+        rule_template: "cve_block_{cve_id}"
+        scope: "all_internet_facing"
+        ttl: "7d"
+      timeout: "60s"
+      retry:
+        max_attempts: 2
+        backoff: "exponential"
+      on_failure: "continue"
+    - id: "step-4"
+      name: "remove_web_shell_persistence"
+      action: "remediation"
+      target: "BODY"
+      parameters:
+        endpoint: "/api/v1/hosts/{hostId}/files/quarantine"
+        method: "POST"
+        patterns: ["*.aspx", "*.jsp", "*.php"]
+        directories: ["wwwroot", "htdocs", "inetpub", "html"]
+        action: "quarantine_and_hash"
+      timeout: "120s"
+      retry:
+        max_attempts: 2
+        backoff: "exponential"
+      on_failure: "continue"
+    - id: "step-5"
+      name: "rotate_service_credentials"
+      action: "remediation"
+      target: "BODY"
+      parameters:
+        endpoint: "/api/v1/credentials/rotate"
+        method: "POST"
+        scope: "host_service_accounts"
+        host_id: "{target_host}"
+      timeout: "120s"
+      retry:
+        max_attempts: 2
+        backoff: "exponential"
+      on_failure: "rollback"
+    - id: "step-6"
+      name: "trigger_emergency_patch"
+      action: "remediation"
+      target: "BODY"
+      parameters:
+        endpoint: "/api/v1/patching/emergency"
+        method: "POST"
+        cve_id: "{cve_id}"
+        priority: "P0"
+        target_group: "internet_facing_assets"
+      timeout: "300s"
+      retry:
+        max_attempts: 2
+        backoff: "exponential"
+      on_failure: "continue"
+    - id: "step-7"
+      name: "validate_patch_and_lift_containment"
+      action: "verification"
+      target: "BODY"
+      parameters:
+        endpoint: "/api/v1/hosts/{hostId}/vulnerability-scan"
+        method: "POST"
+        scan_type: "targeted"
+        cve_id: "{cve_id}"
+      timeout: "300s"
+      retry:
+        max_attempts: 2
+        backoff: "exponential"
+      on_failure: "skip"
+    - id: "step-8"
+      name: "create_incident_ticket"
+      action: "notification"
+      target: "INTERNAL"
+      parameters:
+        channel: "#soc-critical"
+        template: "exploit_chain_incident"
+        ticket_system: "jira"
+        severity: "P1"
+        title: "CVE Exploit Chain Contained — {target_host}"
+      timeout: "30s"
+      retry:
+        max_attempts: 2
+        backoff: "exponential"
+      on_failure: "skip"
+
+  outputs:
+    - name: "containment_status"
+      type: "string"
+      description: "Final status of host containment and patching"
+    - name: "blast_radius_report"
+      type: "object"
+      description: "Assessment of lateral movement risk and affected assets"
+    - name: "patched_assets"
+      type: "array"
+      description: "List of assets that received emergency patches"
+
+  rollback:
+    steps:
+      - id: "rollback-1"
+        name: "lift_network_containment"
+        action: "api_call"
+        target: "EDGE"
+        parameters:
+          action: "lift_containment"
+          host: "{target_host}"
+      - id: "rollback-2"
+        name: "restore_original_waf_rules"
+        action: "api_call"
+        target: "EDGE"
+        parameters:
+          action: "remove_virtual_patch"
+          rule_id: "cve_block_{cve_id}"
+
+  governance:
+    requires_brain_oversight: true
+    max_blast_radius: "segment"
+    audit_level: "verbose"
+    human_approval_required: true

--- a/packages/004_rapid_vulnerability_exploit_emergency_patch_defense/policy.yaml
+++ b/packages/004_rapid_vulnerability_exploit_emergency_patch_defense/policy.yaml
@@ -1,0 +1,103 @@
+apiVersion: soac.io/v1
+kind: Policy
+
+metadata:
+  name: "emergency-patch-defense-policy"
+  version: "1.0.0"
+  author: "SOaC Community"
+  created: "2026-03-28T00:00:00Z"
+  package_id: "pkg-004"
+  scope: "package"
+  tags: ["pkg-004", "vulnerability-management", "patching", "governance"]
+
+spec:
+  description: "Governs emergency patch response timelines, compensating control requirements for unpatched systems, internet-facing asset inventory management, and vulnerability disclosure procedures."
+
+  environments:
+    - name: "lab"
+      mode: "simulate"
+      data_handling: "synthetic"
+      network_access: "isolated"
+      persistence: "ephemeral"
+      patching_policy:
+        sla_critical_hours: 24
+        sla_high_hours: 72
+        compensating_controls_required: false
+    - name: "staging"
+      mode: "audit"
+      data_handling: "anonymized"
+      network_access: "restricted"
+      persistence: "persistent"
+      patching_policy:
+        sla_critical_hours: 24
+        sla_high_hours: 72
+        compensating_controls_required: true
+        virtual_patching_enabled: true
+    - name: "production"
+      mode: "enforce"
+      data_handling: "live"
+      network_access: "full"
+      persistence: "persistent"
+      patching_policy:
+        sla_critical_hours: 24
+        sla_high_hours: 72
+        sla_medium_hours: 168
+        compensating_controls_required: true
+        virtual_patching_enabled: true
+        require_vulnerability_scan_post_patch: true
+
+  actions:
+    allowed:
+      - "detect"
+      - "alert"
+      - "enrich"
+      - "contain_host"
+      - "deploy_virtual_patch"
+      - "quarantine_file"
+      - "rotate_credentials"
+      - "trigger_emergency_patch"
+      - "vulnerability_scan"
+      - "notify"
+    blocked:
+      - "delete_data"
+      - "exfiltrate"
+      - "disable_logging"
+      - "disable_waf"
+      - "skip_patch_validation"
+    requires_approval:
+      - "contain_host"
+      - "trigger_emergency_patch"
+      - "lift_containment"
+
+  access_control:
+    roles:
+      - name: "soc_analyst"
+        permissions: ["read", "execute", "contain_host"]
+      - name: "vuln_management_engineer"
+        permissions: ["read", "write", "trigger_emergency_patch", "vulnerability_scan"]
+      - name: "detection_engineer"
+        permissions: ["read", "write", "execute"]
+      - name: "admin"
+        permissions: ["read", "write", "execute", "admin"]
+    authentication:
+      required: true
+      methods: ["sso", "mfa"]
+
+  compliance:
+    frameworks: ["NIST CSF", "MITRE ATT&CK", "CIS Controls v8", "ISO 27001"]
+    controls: ["DE.CM-8", "RS.MI-3", "PR.IP-12", "ID.RA-1"]
+    review_frequency: "monthly"
+    vulnerability_management:
+      scanning_cadence: "weekly"
+      internet_facing_inventory_required: true
+      compensating_control_documentation_required: true
+      patch_validation_required: true
+
+  audit:
+    log_level: "verbose"
+    retention: "365d"
+    immutable: true
+    patch_audit:
+      track_sla_compliance: true
+      track_compensating_controls: true
+      alert_on_sla_breach: true


### PR DESCRIPTION
Adds root-level content files for pkg-004 (Rapid Vulnerability Exploit & Emergency Patch Defense):

- **detection.yaml** — KQL correlation (exploit attempts + web shell spawn/drop), Sigma, Splunk SPL, CrowdStrike hunt, Wazuh rules (100301-100303). 3 test cases.
- **playbook.yaml** — 8-step CLAW: isolate host → blast radius → WAF virtual patch → quarantine web shells → rotate creds → emergency patch → validate → P1 incident
- **policy.yaml** — Emergency patch SLA (24h critical, 72h high), compensating controls governance, internet-facing inventory, NIST/CIS/ISO compliance