### PR TITLE
feat: add detection, playbook, policy to 005_saas_oauth_integration_risk_defense

### DIFF
--- a/packages/005_saas_oauth_integration_risk_defense/detection.yaml
+++ b/packages/005_saas_oauth_integration_risk_defense/detection.yaml
@@ -1,0 +1,172 @@
+apiVersion: soac.io/v1
+kind: DetectionRule
+
+metadata:
+  name: "saas-oauth-integration-risk-detection"
+  version: "1.0.0"
+  author: "SOaC Community"
+  created: "2026-03-28T00:00:00Z"
+  package_id: "pkg-005"
+  mitre_attack:
+    - technique: "T1098.003"
+      tactic: "Persistence"
+    - technique: "T1566.002"
+      tactic: "Initial Access"
+    - technique: "T1567"
+      tactic: "Exfiltration"
+    - technique: "T1528"
+      tactic: "Credential Access"
+    - technique: "T1530"
+      tactic: "Collection"
+  severity: "HIGH"
+  confidence: "HIGH"
+  tags: ["pkg-005", "saas", "oauth", "consent-phishing", "exfiltration"]
+
+spec:
+  description: "Detects OAuth consent phishing, illicit consent grants to over-permissioned third-party applications, suspicious token usage patterns, SaaS-to-SaaS lateral movement, and bulk data exfiltration via SaaS integration APIs."
+
+  data_sources:
+    - name: "Azure AD Audit Logs"
+      type: "api"
+      fields: ["activityDisplayName", "targetResources", "initiatedBy", "additionalDetails"]
+    - name: "Microsoft 365 Unified Audit Log"
+      type: "api"
+      fields: ["Operation", "UserId", "ClientIP", "ObjectId"]
+    - name: "Google Workspace Admin Logs"
+      type: "api"
+      fields: ["event.name", "actor.email", "parameters"]
+
+  logic:
+    type: "correlation"
+    timewindow: "15m"
+    implementations:
+      sentinel:
+        kql: |
+          // Detect illicit OAuth consent grants with suspicious permissions
+          let consent_grants = AuditLogs
+          | where OperationName == "Consent to application"
+          | extend AppName = tostring(TargetResources[0].displayName)
+          | extend Permissions = tostring(TargetResources[0].modifiedProperties[0].newValue)
+          | where Permissions has_any ("Mail.ReadWrite", "Files.ReadWrite.All", "User.ReadWrite.All", "Directory.ReadWrite.All", "Mail.Send")
+          | project ConsentTime=TimeGenerated, UserPrincipalName=tostring(InitiatedBy.user.userPrincipalName), AppName, Permissions;
+          // Detect bulk data access following consent
+          let bulk_access = OfficeActivity
+          | where Operation in ("FileAccessed", "FileDownloaded", "FileSyncDownloadedFull")
+          | summarize FileCount=count(), Files=make_set(SourceFileName, 20) by UserId, ClientIP, bin(TimeGenerated, 5m)
+          | where FileCount > 50;
+          // Correlate consent grant with bulk access
+          consent_grants
+          | join kind=inner (bulk_access) on $left.UserPrincipalName == $right.UserId
+          | where datetime_diff('minute', TimeGenerated, ConsentTime) between (0 .. 60)
+          | project ConsentTime, UserPrincipalName, AppName, Permissions, FileCount, Files
+      sigma:
+        rule: |
+          title: Suspicious OAuth Application Consent with High Privileges
+          status: experimental
+          logsource:
+            product: azure
+            service: auditlogs
+          detection:
+            selection:
+              properties.message: Consent to application
+            filter_permissions:
+              TargetResources.modifiedProperties.newValue|contains:
+                - 'Mail.ReadWrite'
+                - 'Files.ReadWrite.All'
+                - 'User.ReadWrite.All'
+                - 'Directory.ReadWrite.All'
+            condition: selection and filter_permissions
+          level: high
+          tags:
+            - attack.persistence
+            - attack.t1098.003
+            - attack.initial_access
+            - attack.t1566.002
+      splunk:
+        spl: |
+          index=o365 sourcetype="o365:management:activity" Operation="Consent to application"
+          | spath output=app_name path=Target{}.Name
+          | spath output=permissions path=ModifiedProperties{}.NewValue
+          | where match(permissions, "(Mail\\.ReadWrite|Files\\.ReadWrite\\.All|User\\.ReadWrite\\.All|Directory\\.ReadWrite\\.All)")
+          | eval risk_score=case(
+              match(permissions, "Directory\\.ReadWrite\\.All"), 95,
+              match(permissions, "Mail\\.ReadWrite"), 85,
+              match(permissions, "Files\\.ReadWrite\\.All"), 90,
+              true(), 75)
+          | stats count min(_time) as first_seen max(_time) as last_seen values(app_name) as apps values(permissions) as granted_permissions by UserId
+          | sort -risk_score
+      crowdstrike:
+        hunt: |
+          // CrowdStrike Falcon Identity Protection: Suspicious OAuth consent
+          event_simpleName=OAuthAppConsent
+          | PermissionLevel IN ("high", "critical")
+          | stats count values(AppName) values(GrantedScopes) by UserPrincipalName timestamp
+          | where count >= 1
+          | sort -timestamp
+      wazuh:
+        rule: |
+          <group name="saas,oauth,consent-phishing,">
+            <rule id="100401" level="13">
+              <if_sid>99000</if_sid>
+              <field name="azure.operationName">Consent to application</field>
+              <field name="azure.properties.targetResources" type="pcre2">Mail\.ReadWrite|Files\.ReadWrite\.All</field>
+              <description>Suspicious OAuth consent grant with high-privilege permissions</description>
+              <mitre>
+                <id>T1098.003</id>
+                <id>T1566.002</id>
+              </mitre>
+            </rule>
+            <rule id="100402" level="12">
+              <if_sid>99000</if_sid>
+              <field name="o365.Operation">FileDownloaded</field>
+              <field name="o365.ObjectId" type="pcre2">\.xlsx|\.docx|\.pdf|\.csv</field>
+              <description>Bulk file download from SaaS platform after OAuth consent</description>
+              <mitre>
+                <id>T1530</id>
+                <id>T1567</id>
+              </mitre>
+            </rule>
+            <rule id="100403" level="14">
+              <if_sid>100401</if_sid>
+              <frequency>3</frequency>
+              <timeframe>300</timeframe>
+              <description>Multiple high-privilege OAuth consent grants in short window [Consent Phishing Campaign]</description>
+              <mitre>
+                <id>T1098.003</id>
+                <id>T1566.002</id>
+              </mitre>
+            </rule>
+          </group>
+
+  tuning:
+    threshold: 1
+    whitelist: ["Microsoft Flow", "Power Automate", "SharePoint Online"]
+    noise_reduction: "dedup_by_user_and_app"
+
+  response:
+    playbook: "saas-oauth-abuse-containment"
+    escalation: "auto"
+    notify: ["soc-team", "identity-team", "saas-admin-team"]
+
+  test_cases:
+    - name: "positive-consent-phishing"
+      description: "OAuth consent grant with Mail.ReadWrite.All should trigger alert"
+      input:
+        event_type: "consent_grant"
+        permission: "Mail.ReadWrite.All"
+        severity: "HIGH"
+      expected_result: "alert"
+    - name: "positive-bulk-download"
+      description: "More than 50 file downloads within 5 minutes should trigger alert"
+      input:
+        event_type: "file_download"
+        file_count: 75
+        timeframe_minutes: 5
+      expected_result: "alert"
+    - name: "negative-legitimate-consent"
+      description: "Microsoft Flow consent should not trigger alert"
+      input:
+        event_type: "consent_grant"
+        app_name: "Microsoft Flow"
+        permission: "Files.Read"
+      expected_result: "no_alert"

--- a/packages/005_saas_oauth_integration_risk_defense/playbook.yaml
+++ b/packages/005_saas_oauth_integration_risk_defense/playbook.yaml
@@ -1,0 +1,174 @@
+apiVersion: claw.soac.io/v1
+kind: Playbook
+
+metadata:
+  name: "saas-oauth-abuse-containment"
+  version: "1.0.0"
+  author: "SOaC Community"
+  created: "2026-03-28T00:00:00Z"
+  tags: ["pkg-005", "automated-response", "oauth", "saas"]
+  mitre_attack: ["T1098.003", "T1566.002", "T1567", "T1528", "T1530"]
+  severity: "HIGH"
+  package_id: "pkg-005"
+
+spec:
+  description: "Automated response to OAuth consent abuse and SaaS integration compromise. Revokes malicious app consents, enumerates affected permissions, isolates compromised accounts, rotates tokens, assesses data impact, and hardens consent policies."
+
+  trigger:
+    source: "BODY"
+    conditions:
+      - field: "detection_type"
+        operator: "in"
+        value: ["illicit_consent_grant", "oauth_abuse_detected", "saas_bulk_exfiltration"]
+    cooldown: "5m"
+
+  inputs:
+    - name: "detection_event"
+      type: "object"
+      required: true
+      description: "The detection event payload from The Body"
+    - name: "target_user"
+      type: "string"
+      required: true
+      description: "The affected user principal name"
+    - name: "malicious_app_id"
+      type: "string"
+      required: false
+      description: "The OAuth application ID to revoke"
+
+  steps:
+    - id: "step-1"
+      name: "revoke_malicious_app_consent"
+      action: "containment"
+      target: "BODY"
+      parameters:
+        endpoint: "/api/v1/oauth/apps/{appId}/revoke"
+        method: "POST"
+        provider: "entra_id"
+        revoke_type: "app_and_delegated"
+      timeout: "60s"
+      retry:
+        max_attempts: 3
+        backoff: "exponential"
+      on_failure: "halt"
+    - id: "step-2"
+      name: "enumerate_all_app_permissions"
+      action: "enrichment"
+      target: "BODY"
+      parameters:
+        endpoint: "/api/v1/users/{userId}/app-permissions"
+        method: "GET"
+        include_delegated: true
+        include_application: true
+      timeout: "60s"
+      retry:
+        max_attempts: 2
+        backoff: "exponential"
+      on_failure: "continue"
+    - id: "step-3"
+      name: "disable_affected_account"
+      action: "containment"
+      target: "BODY"
+      parameters:
+        endpoint: "/api/v1/users/{userId}/disable"
+        method: "POST"
+        provider: "entra_id"
+        reason: "oauth_abuse_investigation"
+      timeout: "30s"
+      retry:
+        max_attempts: 2
+        backoff: "exponential"
+      on_failure: "continue"
+    - id: "step-4"
+      name: "revoke_all_refresh_tokens"
+      action: "containment"
+      target: "BODY"
+      parameters:
+        endpoint: "/api/v1/users/{userId}/tokens/revoke-all"
+        method: "POST"
+        providers: ["entra_id", "google_workspace", "slack"]
+      timeout: "60s"
+      retry:
+        max_attempts: 2
+        backoff: "exponential"
+      on_failure: "continue"
+    - id: "step-5"
+      name: "assess_data_exposure"
+      action: "enrichment"
+      target: "BODY"
+      parameters:
+        endpoint: "/api/v1/dlp/exposure-assessment"
+        method: "POST"
+        user_id: "{target_user}"
+        timeframe: "7d"
+        include_file_access_logs: true
+        include_email_forwarding_rules: true
+      timeout: "120s"
+      retry:
+        max_attempts: 2
+        backoff: "exponential"
+      on_failure: "continue"
+    - id: "step-6"
+      name: "notify_affected_user"
+      action: "notification"
+      target: "INTERNAL"
+      parameters:
+        channel: "email"
+        template: "oauth_abuse_user_notification"
+        recipient: "{target_user}"
+        include_password_reset_link: true
+      timeout: "30s"
+      retry:
+        max_attempts: 2
+        backoff: "exponential"
+      on_failure: "skip"
+    - id: "step-7"
+      name: "create_incident_and_audit_trail"
+      action: "notification"
+      target: "INTERNAL"
+      parameters:
+        channel: "#soc-critical"
+        template: "oauth_abuse_incident"
+        ticket_system: "jira"
+        severity: "P2"
+        title: "OAuth Consent Abuse — {target_user}"
+        attach_exposure_report: true
+      timeout: "30s"
+      retry:
+        max_attempts: 2
+        backoff: "exponential"
+      on_failure: "skip"
+
+  outputs:
+    - name: "revocation_status"
+      type: "string"
+      description: "Status of the malicious app consent revocation"
+    - name: "all_app_permissions"
+      type: "array"
+      description: "Complete list of third-party app permissions for the user"
+    - name: "data_exposure_report"
+      type: "object"
+      description: "Assessment of data accessed by the malicious application"
+
+  rollback:
+    steps:
+      - id: "rollback-1"
+        name: "re_enable_user_account"
+        action: "api_call"
+        target: "BODY"
+        parameters:
+          action: "enable_user"
+          user_id: "{target_user}"
+      - id: "rollback-2"
+        name: "restore_legitimate_app_consents"
+        action: "api_call"
+        target: "BODY"
+        parameters:
+          action: "restore_app_consent"
+          app_id: "{malicious_app_id}"
+
+  governance:
+    requires_brain_oversight: true
+    max_blast_radius: "user"
+    audit_level: "verbose"
+    human_approval_required: false

--- a/packages/005_saas_oauth_integration_risk_defense/policy.yaml
+++ b/packages/005_saas_oauth_integration_risk_defense/policy.yaml
@@ -1,0 +1,106 @@
+apiVersion: soac.io/v1
+kind: Policy
+
+metadata:
+  name: "saas-oauth-integration-risk-policy"
+  version: "1.0.0"
+  author: "SOaC Community"
+  created: "2026-03-28T00:00:00Z"
+  package_id: "pkg-005"
+  scope: "package"
+  tags: ["pkg-005", "saas", "oauth", "governance", "integration-risk"]
+
+spec:
+  description: "Governs OAuth application consent policies, third-party SaaS integration risk management, token lifecycle controls, and data access governance for cloud application integrations."
+
+  environments:
+    - name: "lab"
+      mode: "simulate"
+      data_handling: "synthetic"
+      network_access: "isolated"
+      persistence: "ephemeral"
+      oauth_policy:
+        consent_model: "unrestricted"
+        allow_unverified_publishers: true
+    - name: "staging"
+      mode: "audit"
+      data_handling: "anonymized"
+      network_access: "restricted"
+      persistence: "persistent"
+      oauth_policy:
+        consent_model: "admin_consent_required"
+        allow_unverified_publishers: false
+        token_lifetime_hours: 8
+    - name: "production"
+      mode: "enforce"
+      data_handling: "live"
+      network_access: "full"
+      persistence: "persistent"
+      oauth_policy:
+        consent_model: "admin_consent_required"
+        allow_unverified_publishers: false
+        token_lifetime_hours: 4
+        require_app_allowlist: true
+        max_permission_scope: "delegated_only"
+        block_legacy_auth: true
+
+  actions:
+    allowed:
+      - "detect"
+      - "alert"
+      - "enrich"
+      - "revoke_consent"
+      - "revoke_tokens"
+      - "disable_account"
+      - "assess_exposure"
+      - "audit_permissions"
+      - "notify"
+    blocked:
+      - "delete_data"
+      - "exfiltrate"
+      - "disable_logging"
+      - "grant_consent_programmatically"
+      - "bypass_admin_consent"
+    requires_approval:
+      - "disable_account"
+      - "org_wide_consent_revocation"
+      - "modify_consent_policy"
+
+  access_control:
+    roles:
+      - name: "soc_analyst"
+        permissions: ["read", "execute", "revoke_consent"]
+      - name: "saas_admin"
+        permissions: ["read", "write", "audit_permissions", "modify_consent_policy"]
+      - name: "identity_engineer"
+        permissions: ["read", "write", "revoke_tokens", "disable_account"]
+      - name: "admin"
+        permissions: ["read", "write", "execute", "admin"]
+    authentication:
+      required: true
+      methods: ["sso", "mfa"]
+    conditional_access:
+      saas_admin_actions:
+        require_pim_activation: true
+        require_mfa_step_up: true
+        allowed_locations: ["corporate_network", "vpn"]
+
+  compliance:
+    frameworks: ["NIST CSF", "MITRE ATT&CK", "CIS Controls v8", "ISO 27001"]
+    controls: ["PR.AC-4", "DE.CM-7", "RS.MI-1", "PR.DS-5"]
+    review_frequency: "quarterly"
+    saas_governance:
+      app_review_cadence: "quarterly"
+      permission_audit_cadence: "monthly"
+      shadow_it_discovery: "continuous"
+      data_classification_required: true
+
+  audit:
+    log_level: "verbose"
+    retention: "365d"
+    immutable: true
+    oauth_audit:
+      track_consent_grants: true
+      track_token_usage: true
+      track_permission_changes: true
+      alert_on_new_high_privilege_app: true


### PR DESCRIPTION
Adds root-level content files for pkg-005 (SaaS OAuth & Integration Risk Defense):

- **detection.yaml** — KQL correlation (consent grants + bulk data access), Sigma, Splunk SPL, CrowdStrike hunt, Wazuh rules (100401-100403). 3 test cases.
- **playbook.yaml** — 7-step CLAW: revoke malicious consent → enumerate permissions → disable account → revoke tokens → assess exposure → notify user → incident ticket
- **policy.yaml** — OAuth allowlist enforcement, admin consent required, quarterly SaaS review, shadow IT discovery, data classification