### PR TITLE
feat: add detection, playbook, policy to 007_identity_led_intrusion_defense

### DIFF
--- a/packages/007_identity_led_intrusion_defense/detection.yaml
+++ b/packages/007_identity_led_intrusion_defense/detection.yaml
@@ -1,0 +1,188 @@
+apiVersion: soac.io/v1
+kind: DetectionRule
+
+metadata:
+  name: "identity-led-intrusion-detection"
+  version: "1.0.0"
+  author: "SOaC Community"
+  created: "2026-03-28T00:00:00Z"
+  package_id: "pkg-007"
+  mitre_attack:
+    - technique: "T1190"
+      tactic: "Initial Access"
+    - technique: "T1505.003"
+      tactic: "Persistence"
+    - technique: "T1068"
+      tactic: "Privilege Escalation"
+    - technique: "T1021"
+      tactic: "Lateral Movement"
+    - technique: "T1078"
+      tactic: "Defense Evasion"
+    - technique: "T1557"
+      tactic: "Credential Access"
+    - technique: "T1539"
+      tactic: "Credential Access"
+    - technique: "T1550"
+      tactic: "Lateral Movement"
+  severity: "CRITICAL"
+  confidence: "HIGH"
+  tags: ["pkg-007", "identity", "gtr-2025", "lateral-movement", "privilege-escalation"]
+
+spec:
+  description: "Detects identity-led intrusion chains aligned with CrowdStrike GTR-2025 findings: perimeter exploitation, web shell persistence, kernel privilege escalation, RDP/SMB lateral movement, and identity pivot from on-premises to cloud via federated identity abuse."
+
+  data_sources:
+    - name: "Azure AD Sign-In Logs"
+      type: "api"
+      fields: ["userPrincipalName", "ipAddress", "location", "riskState", "authenticationRequirement"]
+    - name: "Endpoint Process Logs"
+      type: "edr"
+      fields: ["process.name", "process.command_line", "process.parent", "user.name"]
+    - name: "Windows Security Event Log"
+      type: "siem"
+      fields: ["EventID", "TargetUserName", "LogonType", "IpAddress"]
+
+  logic:
+    type: "correlation"
+    timewindow: "15m"
+    implementations:
+      sentinel:
+        kql: |
+          // Stage 1: Detect impossible travel or anomalous sign-in
+          let anomalous_signin = SigninLogs
+          | where ResultType == 0
+          | where RiskLevelDuringSignIn in ("high", "medium")
+              or ConditionalAccessStatus == "failure"
+          | summarize SignInCount=count(), DistinctIPs=dcount(IPAddress),
+              Locations=make_set(LocationDetails.city, 5) by UserPrincipalName, bin(TimeGenerated, 15m)
+          | where DistinctIPs > 2 or SignInCount > 10;
+          // Stage 2: Detect MFA fatigue / push bombing
+          let mfa_fatigue = AADNonInteractiveUserSignInLogs
+          | where ResultType == 50074  // MFA required
+          | summarize MFAAttempts=count() by UserPrincipalName, bin(TimeGenerated, 5m)
+          | where MFAAttempts > 5;
+          // Stage 3: Detect token theft indicators (PRT/OAuth replay from new device)
+          let token_replay = SigninLogs
+          | where AuthenticationRequirement == "singleFactorAuthentication"
+          | where TokenIssuerType == "AzureAD"
+          | where DeviceDetail.isCompliant == false or isempty(DeviceDetail.deviceId)
+          | where RiskState has_any ("atRisk", "confirmedCompromised")
+          | project TokenTime=TimeGenerated, UserPrincipalName, IPAddress, DeviceDetail;
+          // Stage 4: Detect cross-cloud pivot (Entra ID to AWS)
+          let aws_pivot = AWSCloudTrail
+          | where EventName in ("AssumeRoleWithSAML", "AssumeRoleWithWebIdentity")
+          | where SourceIPAddress !in ("internal_range")
+          | project AWSTime=TimeGenerated, UserIdentityArn=UserIdentity.Arn, EventName, SourceIPAddress;
+          // Correlate anomalous sign-in with token replay or AWS pivot
+          anomalous_signin
+          | join kind=inner (token_replay) on UserPrincipalName
+          | union (
+              anomalous_signin
+              | join kind=leftouter (aws_pivot) on $left.UserPrincipalName == $right.UserIdentityArn
+          )
+      sigma:
+        rule: |
+          title: MFA Fatigue Attack - Excessive Push Notifications
+          status: experimental
+          logsource:
+            product: azure
+            service: signinlogs
+          detection:
+            selection:
+              ResultType: 50074
+            timeframe: 5m
+            condition: selection | count() by UserPrincipalName > 5
+          level: high
+          tags:
+            - attack.credential_access
+            - attack.t1621
+            - attack.t1078
+      splunk:
+        spl: |
+          index=azure sourcetype="azure:signinlogs" ResultType=0
+          | iplocation IPAddress
+          | stats dc(IPAddress) as unique_ips dc(City) as unique_locations count by UserPrincipalName _time span=15m
+          | where unique_ips > 2 OR unique_locations > 2
+          | eval risk_score=case(
+              unique_locations > 3, 95,
+              unique_ips > 4, 90,
+              unique_ips > 2, 80,
+              true(), 70)
+          | sort -risk_score
+          | table UserPrincipalName unique_ips unique_locations count risk_score _time
+      crowdstrike:
+        hunt: |
+          // CrowdStrike Falcon Identity: Lateral movement via RDP following privilege escalation
+          event_simpleName=UserLogon
+          | LogonType=10  // RemoteInteractive (RDP)
+          | join event_simpleName=ProcessRollup2 [search FileName IN ("whoami.exe", "net.exe", "nltest.exe", "dsquery.exe") earliest=-15m]
+          | stats count values(FileName) as recon_tools by aid UserName RemoteIP
+          | where count >= 2
+      wazuh:
+        rule: |
+          <group name="identity,intrusion,gtr-2025,">
+            <rule id="100901" level="14">
+              <if_sid>60122</if_sid>
+              <field name="win.system.eventID">4625</field>
+              <frequency>10</frequency>
+              <timeframe>300</timeframe>
+              <description>Brute force or MFA fatigue attack — excessive failed logons [GTR-2025]</description>
+              <mitre>
+                <id>T1078</id>
+                <id>T1557</id>
+              </mitre>
+            </rule>
+            <rule id="100902" level="13">
+              <if_sid>60106</if_sid>
+              <field name="win.system.eventID">4624</field>
+              <field name="win.eventdata.logonType">10</field>
+              <description>RDP lateral movement to new host [Identity-Led Intrusion]</description>
+              <mitre>
+                <id>T1021</id>
+                <id>T1550</id>
+              </mitre>
+            </rule>
+            <rule id="100903" level="14">
+              <if_sid>61603</if_sid>
+              <field name="win.eventdata.image" type="pcre2">nltest|dsquery|adfind|bloodhound</field>
+              <description>Active Directory reconnaissance tool execution [Privilege Escalation Chain]</description>
+              <mitre>
+                <id>T1068</id>
+                <id>T1078</id>
+              </mitre>
+            </rule>
+          </group>
+
+  tuning:
+    threshold: 1
+    whitelist: ["break-glass-admin@corp.example.com", "service-account-sync@corp.example.com"]
+    noise_reduction: "dedup_by_user_and_timewindow"
+
+  response:
+    playbook: "identity-intrusion-containment"
+    escalation: "auto"
+    notify: ["soc-team", "identity-team", "cloud-security-team"]
+
+  test_cases:
+    - name: "positive-impossible-travel"
+      description: "Sign-ins from 3+ countries within 15 minutes should trigger alert"
+      input:
+        event_type: "sign_in"
+        unique_locations: 4
+        timeframe_minutes: 10
+        severity: "CRITICAL"
+      expected_result: "alert"
+    - name: "positive-mfa-fatigue"
+      description: "More than 5 MFA push attempts in 5 minutes should trigger alert"
+      input:
+        event_type: "mfa_challenge"
+        attempt_count: 8
+        timeframe_minutes: 5
+      expected_result: "alert"
+    - name: "negative-legitimate-travel"
+      description: "Known break-glass admin account should not trigger alert"
+      input:
+        event_type: "sign_in"
+        user: "break-glass-admin@corp.example.com"
+        unique_locations: 3
+      expected_result: "no_alert"

--- a/packages/007_identity_led_intrusion_defense/playbook.yaml
+++ b/packages/007_identity_led_intrusion_defense/playbook.yaml
@@ -1,0 +1,194 @@
+apiVersion: claw.soac.io/v1
+kind: Playbook
+
+metadata:
+  name: "identity-intrusion-containment"
+  version: "1.0.0"
+  author: "SOaC Community"
+  created: "2026-03-28T00:00:00Z"
+  tags: ["pkg-007", "automated-response", "identity", "gtr-2025"]
+  mitre_attack: ["T1190", "T1505.003", "T1068", "T1021", "T1078", "T1557", "T1539", "T1550"]
+  severity: "CRITICAL"
+  package_id: "pkg-007"
+
+spec:
+  description: "Automated containment and remediation for identity-led intrusion chains. Revokes compromised sessions, forces MFA re-registration, disables account, rotates credentials, audits privileged actions, and contains lateral movement across M365, Entra ID, and AWS."
+
+  trigger:
+    source: "BODY"
+    conditions:
+      - field: "detection_type"
+        operator: "in"
+        value: ["identity_intrusion_chain", "mfa_fatigue_confirmed", "token_replay_detected", "cross_cloud_pivot"]
+    cooldown: "5m"
+
+  inputs:
+    - name: "detection_event"
+      type: "object"
+      required: true
+      description: "The detection event payload from The Body"
+    - name: "target_identity"
+      type: "string"
+      required: true
+      description: "The compromised user principal name"
+    - name: "affected_cloud_accounts"
+      type: "array"
+      required: false
+      description: "List of cloud accounts (AWS, Azure, GCP) associated with the compromised identity"
+
+  steps:
+    - id: "step-1"
+      name: "revoke_all_active_sessions"
+      action: "containment"
+      target: "BODY"
+      parameters:
+        endpoint: "/api/v1/users/{userId}/sessions/revoke-all"
+        method: "POST"
+        providers: ["entra_id", "microsoft_365", "aws_sso"]
+      timeout: "60s"
+      retry:
+        max_attempts: 3
+        backoff: "exponential"
+      on_failure: "halt"
+    - id: "step-2"
+      name: "force_mfa_reregistration"
+      action: "containment"
+      target: "BODY"
+      parameters:
+        endpoint: "/api/v1/users/{userId}/mfa/reset"
+        method: "POST"
+        provider: "entra_id"
+        require_phishing_resistant: true
+        clear_existing_methods: true
+      timeout: "60s"
+      retry:
+        max_attempts: 2
+        backoff: "exponential"
+      on_failure: "continue"
+    - id: "step-3"
+      name: "disable_compromised_account"
+      action: "containment"
+      target: "BODY"
+      parameters:
+        endpoint: "/api/v1/users/{userId}/disable"
+        method: "POST"
+        provider: "entra_id"
+        reason: "identity_intrusion_investigation"
+      timeout: "30s"
+      retry:
+        max_attempts: 2
+        backoff: "exponential"
+      on_failure: "continue"
+    - id: "step-4"
+      name: "rotate_credentials_and_tokens"
+      action: "remediation"
+      target: "BODY"
+      parameters:
+        endpoint: "/api/v1/credentials/rotate-identity"
+        method: "POST"
+        user_id: "{target_identity}"
+        include_service_principals: true
+        include_app_passwords: true
+        include_api_keys: true
+      timeout: "120s"
+      retry:
+        max_attempts: 2
+        backoff: "exponential"
+      on_failure: "rollback"
+    - id: "step-5"
+      name: "audit_privileged_actions"
+      action: "enrichment"
+      target: "BODY"
+      parameters:
+        endpoint: "/api/v1/audit/privileged-actions"
+        method: "POST"
+        user_id: "{target_identity}"
+        timeframe: "72h"
+        include_entra_id: true
+        include_aws_cloudtrail: true
+        include_m365_uam: true
+      timeout: "120s"
+      retry:
+        max_attempts: 2
+        backoff: "exponential"
+      on_failure: "continue"
+    - id: "step-6"
+      name: "contain_lateral_movement"
+      action: "containment"
+      target: "EDGE"
+      parameters:
+        endpoint: "/enforce"
+        method: "POST"
+        action_type: "block_identity"
+        identity: "{target_identity}"
+        scope: ["rdp", "smb", "winrm", "ssh"]
+        ttl: "24h"
+      timeout: "60s"
+      retry:
+        max_attempts: 2
+        backoff: "exponential"
+      on_failure: "continue"
+    - id: "step-7"
+      name: "revoke_aws_federated_sessions"
+      action: "containment"
+      target: "BODY"
+      parameters:
+        endpoint: "/api/v1/aws/sts/revoke-federated"
+        method: "POST"
+        identity: "{target_identity}"
+        revoke_assume_role: true
+      timeout: "60s"
+      retry:
+        max_attempts: 2
+        backoff: "exponential"
+      on_failure: "continue"
+    - id: "step-8"
+      name: "create_p1_incident"
+      action: "notification"
+      target: "INTERNAL"
+      parameters:
+        channel: "#soc-critical"
+        template: "identity_intrusion_incident"
+        ticket_system: "jira"
+        severity: "P1"
+        title: "Identity-Led Intrusion Chain — {target_identity}"
+        attach_audit_report: true
+      timeout: "30s"
+      retry:
+        max_attempts: 2
+        backoff: "exponential"
+      on_failure: "skip"
+
+  outputs:
+    - name: "containment_status"
+      type: "string"
+      description: "Overall status of identity containment and credential rotation"
+    - name: "privileged_action_audit"
+      type: "object"
+      description: "Audit report of all privileged actions by the compromised identity"
+    - name: "lateral_movement_scope"
+      type: "array"
+      description: "List of hosts and services accessed via lateral movement"
+
+  rollback:
+    steps:
+      - id: "rollback-1"
+        name: "re_enable_account"
+        action: "api_call"
+        target: "BODY"
+        parameters:
+          action: "enable_user"
+          user_id: "{target_identity}"
+      - id: "rollback-2"
+        name: "lift_lateral_movement_block"
+        action: "api_call"
+        target: "EDGE"
+        parameters:
+          action: "unblock_identity"
+          identity: "{target_identity}"
+
+  governance:
+    requires_brain_oversight: true
+    max_blast_radius: "org"
+    audit_level: "verbose"
+    human_approval_required: true

--- a/packages/007_identity_led_intrusion_defense/policy.yaml
+++ b/packages/007_identity_led_intrusion_defense/policy.yaml
@@ -1,0 +1,117 @@
+apiVersion: soac.io/v1
+kind: Policy
+
+metadata:
+  name: "identity-led-intrusion-defense-policy"
+  version: "1.0.0"
+  author: "SOaC Community"
+  created: "2026-03-28T00:00:00Z"
+  package_id: "pkg-007"
+  scope: "package"
+  tags: ["pkg-007", "identity", "gtr-2025", "governance", "mfa", "federation"]
+
+spec:
+  description: "Governs identity security controls for defense against identity-led intrusion chains including phishing-resistant MFA enforcement, privileged identity governance, cross-cloud federation security, and session/token binding policies."
+
+  environments:
+    - name: "lab"
+      mode: "simulate"
+      data_handling: "synthetic"
+      network_access: "isolated"
+      persistence: "ephemeral"
+      identity_policy:
+        mfa_enforcement: "optional"
+        session_lifetime_hours: 24
+        allow_legacy_auth: true
+    - name: "staging"
+      mode: "audit"
+      data_handling: "anonymized"
+      network_access: "restricted"
+      persistence: "persistent"
+      identity_policy:
+        mfa_enforcement: "required"
+        phishing_resistant_mfa: false
+        session_lifetime_hours: 12
+        allow_legacy_auth: false
+    - name: "production"
+      mode: "enforce"
+      data_handling: "live"
+      network_access: "full"
+      persistence: "persistent"
+      identity_policy:
+        mfa_enforcement: "required"
+        phishing_resistant_mfa: true
+        accepted_mfa_methods: ["fido2", "windows_hello", "certificate"]
+        blocked_mfa_methods: ["sms", "voice_call"]
+        session_lifetime_hours: 8
+        token_binding: "device_compliant"
+        allow_legacy_auth: false
+        pim_required_for_privileged_roles: true
+        jit_access_max_duration_hours: 4
+
+  actions:
+    allowed:
+      - "detect"
+      - "alert"
+      - "enrich"
+      - "revoke_sessions"
+      - "reset_mfa"
+      - "disable_account"
+      - "rotate_credentials"
+      - "block_lateral_movement"
+      - "revoke_federated_sessions"
+      - "audit_privileged_actions"
+      - "notify"
+    blocked:
+      - "delete_data"
+      - "exfiltrate"
+      - "disable_logging"
+      - "disable_conditional_access"
+      - "grant_permanent_admin"
+    requires_approval:
+      - "disable_account"
+      - "org_wide_session_revocation"
+      - "modify_federation_trust"
+
+  access_control:
+    roles:
+      - name: "soc_analyst"
+        permissions: ["read", "execute", "revoke_sessions", "audit_privileged_actions"]
+      - name: "identity_engineer"
+        permissions: ["read", "write", "reset_mfa", "disable_account", "rotate_credentials"]
+      - name: "cloud_security_engineer"
+        permissions: ["read", "write", "revoke_federated_sessions", "block_lateral_movement"]
+      - name: "admin"
+        permissions: ["read", "write", "execute", "admin", "modify_federation_trust"]
+    authentication:
+      required: true
+      methods: ["fido2", "certificate"]
+    conditional_access:
+      privileged_operations:
+        require_pim_activation: true
+        require_compliant_device: true
+        require_phishing_resistant_mfa: true
+        allowed_locations: ["corporate_network"]
+
+  compliance:
+    frameworks: ["NIST CSF", "MITRE ATT&CK", "CIS Controls v8", "ISO 27001", "CrowdStrike GTR-2025"]
+    controls: ["PR.AC-1", "PR.AC-7", "DE.CM-1", "RS.RP-1", "PR.IP-1"]
+    review_frequency: "quarterly"
+    identity_governance:
+      access_review_cadence: "quarterly"
+      privileged_role_review_cadence: "monthly"
+      federation_trust_review_cadence: "quarterly"
+      stale_account_threshold_days: 90
+      mfa_compliance_target_percent: 100
+
+  audit:
+    log_level: "verbose"
+    retention: "365d"
+    immutable: true
+    identity_audit:
+      track_sign_ins: true
+      track_mfa_events: true
+      track_privilege_escalation: true
+      track_federation_events: true
+      alert_on_impossible_travel: true
+      alert_on_mfa_fatigue: true


### PR DESCRIPTION
Adds root-level content files for pkg-007 (Identity-Led Intrusion Defense GTR-2025):

- **detection.yaml** — KQL correlation (impossible travel + MFA fatigue + token replay + AWS pivot), Sigma, Splunk SPL, CrowdStrike hunt, Wazuh rules (100901-100903). 3 test cases.
- **playbook.yaml** — 8-step CLAW: revoke sessions → force MFA re-reg → disable account → rotate creds → audit privileged actions → block lateral movement → revoke AWS federated → P1 incident
- **policy.yaml** — Phishing-resistant MFA (FIDO2/WHfB), PIM/JIT access, federation trust review, token binding, GTR-2025/NIST/CIS/ISO compliance