### PR TITLE
fix(pkg-013): simulation_steps string→object + schema standardization

### DIFF
--- a/packages/013_ci_cd_supply_chain_defense/manifest.json
+++ b/packages/013_ci_cd_supply_chain_defense/manifest.json
@@ -16,7 +16,10 @@
     "github-actions",
     "trivy",
     "artifact-poisoning",
-    "gtr-2025"
+    "gtr-2025",
+    "red_team",
+    "blue_team",
+    "soc_manager"
   ],
   "platform_targets": [
     "GitHub Actions",
@@ -44,14 +47,55 @@
     "T1550.001"
   ],
   "simulation_steps": [
-    "Steal CI/CD service account token via misconfiguration or prior compromise",
-    "Access release automation environment or workflow repository",
-    "Force-push malicious code to trusted version tags",
-    "Poison downstream builds that consume mutated tags",
-    "Harvest secrets from runner filesystem and environment variables",
-    "Attempt cloud pivot using exposed credentials or tokens",
-    "Stage or exfiltrate data to attacker-controlled repo or network endpoint",
-    "Trigger recovery, secret rotation, artifact validation, and incident escalation"
+    {
+      "step_index": 1,
+      "title": "Steal CI/CD service account token via misconfiguration or prior compromise",
+      "role": "red_team",
+      "description": "Action: Steal CI/CD service account token via misconfiguration or prior compromise"
+    },
+    {
+      "step_index": 2,
+      "title": "Access release automation environment or workflow repository",
+      "role": "red_team",
+      "description": "Action: Access release automation environment or workflow repository"
+    },
+    {
+      "step_index": 3,
+      "title": "Force-push malicious code to trusted version tags",
+      "role": "red_team",
+      "description": "Action: Force-push malicious code to trusted version tags"
+    },
+    {
+      "step_index": 4,
+      "title": "Poison downstream builds that consume mutated tags",
+      "role": "red_team",
+      "description": "Action: Poison downstream builds that consume mutated tags"
+    },
+    {
+      "step_index": 5,
+      "title": "Harvest secrets from runner filesystem and environment variables",
+      "role": "red_team",
+      "description": "Action: Harvest secrets from runner filesystem and environment variables"
+    },
+    {
+      "step_index": 6,
+      "title": "Attempt cloud pivot using exposed credentials or tokens",
+      "role": "red_team",
+      "description": "Action: Attempt cloud pivot using exposed credentials or tokens"
+    },
+    {
+      "step_index": 7,
+      "title": "Stage or exfiltrate data to attacker-controlled repo or network endpoint",
+      "role": "red_team",
+      "description": "Action: Stage or exfiltrate data to attacker-controlled repo or network endpoint"
+    },
+    {
+      "step_index": 8,
+      "title": "Trigger recovery, secret rotation, artifact validation, and incident escalation",
+      "role": "blue_team",
+      "description": "Action: Trigger recovery, secret rotation, artifact validation, and incident escalation"
+    }
   ],
-  "linkedin_cta": "TRIVY"
+  "linkedin_cta": "TRIVY",
+  "difficulty_label": "Elite"
 }


### PR DESCRIPTION
### Changes
- Convert simulation_steps from 8 strings to 8 objects (step_index, title, role, description)
- Add difficulty_label: Elite
- Add role tags: red_team, blue_team, soc_manager

Fixes CI validation: "/simulation_steps/N must be object"