### PR TITLE
fix: MITRE-aligned simulation_steps v2.1 — all 13 packages

### DIFF
--- a/packages/001_0apt_identity_pivot/manifest.json
+++ b/packages/001_0apt_identity_pivot/manifest.json
@@ -13,7 +13,10 @@
     "phishing",
     "session-hijack",
     "okta",
-    "entra-id"
+    "entra-id",
+    "red_team",
+    "blue_team",
+    "soc_manager"
   ],
   "threat_actor": "0APT",
   "github_path": "packages/001_0apt_identity_pivot",
@@ -45,42 +48,57 @@
   "simulation_steps": [
     {
       "step_index": 1,
-      "role": "Red Team",
       "title": "Send AitM Phishing Email",
-      "technique": [
+      "description": "",
+      "role": "red_team",
+      "phase": "Initial Access",
+      "pillar": "Offense",
+      "mitre_techniques": [
         "T1566.002"
       ]
     },
     {
       "step_index": 2,
-      "role": "Red Team",
       "title": "Intercept Credentials via AitM Proxy",
-      "technique": [
+      "description": "",
+      "role": "blue_team",
+      "phase": "Credential Access",
+      "pillar": "Detect",
+      "mitre_techniques": [
         "T1557.001"
       ]
     },
     {
       "step_index": 3,
-      "role": "Red Team",
       "title": "Steal Session Token",
-      "technique": [
+      "description": "",
+      "role": "blue_team",
+      "phase": "Credential Access",
+      "pillar": "Detect",
+      "mitre_techniques": [
         "T1539"
       ]
     },
     {
       "step_index": 4,
-      "role": "Red Team",
       "title": "Replay Session from Attacker Infrastructure",
-      "technique": [
+      "description": "",
+      "role": "blue_team",
+      "phase": "Credential Access",
+      "pillar": "Detect",
+      "mitre_techniques": [
         "T1539",
         "T1078.004"
       ]
     },
     {
       "step_index": 5,
-      "role": "Red Team",
       "title": "Pivot to Cloud Applications",
-      "technique": [
+      "description": "",
+      "role": "red_team",
+      "phase": "Initial Access",
+      "pillar": "Offense",
+      "mitre_techniques": [
         "T1078.004"
       ]
     }
@@ -96,5 +114,6 @@
   "created": "2026-03-28",
   "updated": "2026-03-28",
   "license": "Apache-2.0",
-  "author": "SOaC Community"
+  "author": "SOaC Community",
+  "difficulty_label": "Advanced"
 }

--- a/packages/002_qilin_ransomware_containment/manifest.json
+++ b/packages/002_qilin_ransomware_containment/manifest.json
@@ -13,7 +13,10 @@
     "encryption",
     "containment",
     "lateral-movement",
-    "vss-deletion"
+    "vss-deletion",
+    "red_team",
+    "blue_team",
+    "soc_manager"
   ],
   "threat_actor": "Qilin",
   "github_path": "packages/002_qilin_ransomware_containment",
@@ -45,39 +48,69 @@
   "simulation_steps": [
     {
       "step_index": 1,
-      "role": "Red Team",
       "title": "Compromised VPN Credential",
-      "technique": []
+      "description": "",
+      "role": "ciso",
+      "phase": "Impact",
+      "pillar": "Govern",
+      "mitre_techniques": [
+        "T1486"
+      ]
     },
     {
       "step_index": 2,
-      "role": "Red Team",
       "title": "Network Reconnaissance",
-      "technique": []
+      "description": "",
+      "role": "ciso",
+      "phase": "Impact",
+      "pillar": "Govern",
+      "mitre_techniques": [
+        "T1490"
+      ]
     },
     {
       "step_index": 3,
-      "role": "Red Team",
       "title": "Chrome Credential Harvesting",
-      "technique": []
+      "description": "",
+      "role": "ciso",
+      "phase": "Impact",
+      "pillar": "Govern",
+      "mitre_techniques": [
+        "T1489"
+      ]
     },
     {
       "step_index": 4,
-      "role": "Red Team",
       "title": "SMB Propagation",
-      "technique": []
+      "description": "",
+      "role": "soc_team",
+      "phase": "Lateral Movement",
+      "pillar": "Respond",
+      "mitre_techniques": [
+        "T1021.002"
+      ]
     },
     {
       "step_index": 6,
-      "role": "Red Team",
       "title": "Anti-Recovery Preparation",
-      "technique": []
+      "description": "",
+      "role": "soc_team",
+      "phase": "Lateral Movement",
+      "pillar": "Respond",
+      "mitre_techniques": [
+        "T1570"
+      ]
     },
     {
       "step_index": 8,
-      "role": "Red Team",
       "title": "Ransomware Deployment",
-      "technique": []
+      "description": "",
+      "role": "ciso",
+      "phase": "Impact",
+      "pillar": "Govern",
+      "mitre_techniques": [
+        "T1486"
+      ]
     }
   ],
   "lab_scenarios": [
@@ -91,5 +124,6 @@
   "created": "2025-03-28",
   "updated": "",
   "license": "MIT",
-  "author": "SOaC Framework"
+  "author": "SOaC Framework",
+  "difficulty_label": "Advanced"
 }

--- a/packages/003_cloud_control_plane_hijack/manifest.json
+++ b/packages/003_cloud_control_plane_hijack/manifest.json
@@ -13,7 +13,10 @@
     "privilege-escalation",
     "azure",
     "aws",
-    "control-plane"
+    "control-plane",
+    "red_team",
+    "blue_team",
+    "soc_manager"
   ],
   "threat_actor": "Lynx",
   "github_path": "packages/003_cloud_control_plane_hijack",
@@ -47,39 +50,69 @@
   "simulation_steps": [
     {
       "step_index": 1,
-      "role": "Red Team",
       "title": "Compromised IAM Credentials",
-      "technique": []
+      "description": "",
+      "role": "red_team",
+      "phase": "Persistence",
+      "pillar": "Offense",
+      "mitre_techniques": [
+        "T1098.001"
+      ]
     },
     {
       "step_index": 2,
-      "role": "Red Team",
       "title": "Cloud Environment Mapping",
-      "technique": []
+      "description": "",
+      "role": "red_team",
+      "phase": "Initial Access",
+      "pillar": "Offense",
+      "mitre_techniques": [
+        "T1078.004"
+      ]
     },
     {
       "step_index": 3,
-      "role": "Red Team",
       "title": "Admin Policy Attachment",
-      "technique": []
+      "description": "",
+      "role": "red_team",
+      "phase": "Defense Evasion",
+      "pillar": "Offense",
+      "mitre_techniques": [
+        "T1562.008"
+      ]
     },
     {
       "step_index": 5,
-      "role": "Red Team",
       "title": "Disable Logging",
-      "technique": []
+      "description": "",
+      "role": "red_team",
+      "phase": "Defense Evasion",
+      "pillar": "Offense",
+      "mitre_techniques": [
+        "T1550.001"
+      ]
     },
     {
       "step_index": 7,
-      "role": "Red Team",
       "title": "Cross-Account Pivot",
-      "technique": []
+      "description": "",
+      "role": "red_team",
+      "phase": "Privilege Escalation",
+      "pillar": "Offense",
+      "mitre_techniques": [
+        "T1578"
+      ]
     },
     {
       "step_index": 8,
-      "role": "Red Team",
       "title": "Network Exposure",
-      "technique": []
+      "description": "",
+      "role": "red_team",
+      "phase": "Persistence",
+      "pillar": "Offense",
+      "mitre_techniques": [
+        "T1098.001"
+      ]
     }
   ],
   "lab_scenarios": [
@@ -93,5 +126,6 @@
   "created": "2025-03-28",
   "updated": "",
   "license": "MIT",
-  "author": "SOaC Framework"
+  "author": "SOaC Framework",
+  "difficulty_label": "Advanced"
 }

--- a/packages/004_rapid_vulnerability_exploit_emergency_patch_defense/manifest.json
+++ b/packages/004_rapid_vulnerability_exploit_emergency_patch_defense/manifest.json
@@ -14,7 +14,10 @@
     "cve",
     "zero-day",
     "web-shell",
-    "virtual-patching"
+    "virtual-patching",
+    "red_team",
+    "blue_team",
+    "soc_manager"
   ],
   "threat_actor": null,
   "github_path": "packages/004_rapid_vulnerability_exploit_emergency_patch_defense",
@@ -48,21 +51,36 @@
   "simulation_steps": [
     {
       "step_index": 1,
-      "role": "Red Team",
       "title": "Perimeter Device Exploit",
-      "technique": []
+      "description": "",
+      "role": "red_team",
+      "phase": "Initial Access",
+      "pillar": "Offense",
+      "mitre_techniques": [
+        "T1190"
+      ]
     },
     {
       "step_index": 2,
-      "role": "Red Team",
       "title": "System Reconnaissance",
-      "technique": []
+      "description": "",
+      "role": "red_team",
+      "phase": "Execution",
+      "pillar": "Offense",
+      "mitre_techniques": [
+        "T1059"
+      ]
     },
     {
       "step_index": 3,
-      "role": "Red Team",
       "title": "Web Shell Deployment",
-      "technique": []
+      "description": "",
+      "role": "red_team",
+      "phase": "Persistence",
+      "pillar": "Offense",
+      "mitre_techniques": [
+        "T1505.003"
+      ]
     }
   ],
   "lab_scenarios": [
@@ -76,5 +94,6 @@
   "created": "2025-03-28",
   "updated": "",
   "license": "MIT",
-  "author": "SOaC Framework"
+  "author": "SOaC Framework",
+  "difficulty_label": "Elite"
 }

--- a/packages/005_saas_oauth_integration_risk_defense/manifest.json
+++ b/packages/005_saas_oauth_integration_risk_defense/manifest.json
@@ -12,7 +12,10 @@
     "oauth",
     "token-abuse",
     "data-exfiltration",
-    "consent-phishing"
+    "consent-phishing",
+    "red_team",
+    "blue_team",
+    "soc_manager"
   ],
   "threat_actor": null,
   "github_path": "packages/005_saas_oauth_integration_risk_defense",
@@ -51,27 +54,47 @@
   "simulation_steps": [
     {
       "step_index": 1,
-      "role": "Red Team",
       "title": "Consent Phishing Campaign",
-      "technique": []
+      "description": "",
+      "role": "red_team",
+      "phase": "Persistence",
+      "pillar": "Offense",
+      "mitre_techniques": [
+        "T1098.003"
+      ]
     },
     {
       "step_index": 2,
-      "role": "Red Team",
       "title": "Illicit Consent Grant",
-      "technique": []
+      "description": "",
+      "role": "red_team",
+      "phase": "Initial Access",
+      "pillar": "Offense",
+      "mitre_techniques": [
+        "T1566.002"
+      ]
     },
     {
       "step_index": 3,
-      "role": "Red Team",
       "title": "Mailbox Enumeration",
-      "technique": []
+      "description": "",
+      "role": "soc_team",
+      "phase": "Exfiltration",
+      "pillar": "Respond",
+      "mitre_techniques": [
+        "T1567"
+      ]
     },
     {
       "step_index": 5,
-      "role": "Red Team",
       "title": "Bulk File Download",
-      "technique": []
+      "description": "",
+      "role": "blue_team",
+      "phase": "Credential Access",
+      "pillar": "Detect",
+      "mitre_techniques": [
+        "T1528"
+      ]
     }
   ],
   "lab_scenarios": [
@@ -85,5 +108,6 @@
   "created": "2025-03-28",
   "updated": "",
   "license": "MIT",
-  "author": "SOaC Framework"
+  "author": "SOaC Framework",
+  "difficulty_label": "Advanced"
 }

--- a/packages/006_evilproxy_credential_harvest/manifest.json
+++ b/packages/006_evilproxy_credential_harvest/manifest.json
@@ -13,7 +13,10 @@
     "phishing",
     "mfa-bypass",
     "aitm",
-    "session-theft"
+    "session-theft",
+    "red_team",
+    "blue_team",
+    "soc_manager"
   ],
   "threat_actor": "EvilProxy",
   "github_path": "packages/006_evilproxy_credential_harvest",
@@ -45,33 +48,58 @@
   "simulation_steps": [
     {
       "step_index": 1,
-      "role": "Red Team",
       "title": "EvilProxy Link Delivery",
-      "technique": []
+      "description": "",
+      "role": "blue_team",
+      "phase": "Credential Access",
+      "pillar": "Detect",
+      "mitre_techniques": [
+        "T1557.001"
+      ]
     },
     {
       "step_index": 2,
-      "role": "Red Team",
       "title": "AitM Session Interception",
-      "technique": []
+      "description": "",
+      "role": "blue_team",
+      "phase": "Credential Access",
+      "pillar": "Detect",
+      "mitre_techniques": [
+        "T1539"
+      ]
     },
     {
       "step_index": 3,
-      "role": "Red Team",
       "title": "MFA Push Bombing",
-      "technique": []
+      "description": "",
+      "role": "red_team",
+      "phase": "Defense Evasion",
+      "pillar": "Offense",
+      "mitre_techniques": [
+        "T1621"
+      ]
     },
     {
       "step_index": 5,
-      "role": "Red Team",
       "title": "Session Replay",
-      "technique": []
+      "description": "",
+      "role": "red_team",
+      "phase": "Initial Access",
+      "pillar": "Offense",
+      "mitre_techniques": [
+        "T1566.002"
+      ]
     },
     {
       "step_index": 6,
-      "role": "Red Team",
       "title": "Inbox Rule Creation",
-      "technique": []
+      "description": "",
+      "role": "blue_team",
+      "phase": "Credential Access",
+      "pillar": "Detect",
+      "mitre_techniques": [
+        "T1114.003"
+      ]
     }
   ],
   "lab_scenarios": [
@@ -85,5 +113,6 @@
   "created": "2025-03-28",
   "updated": "",
   "license": "MIT",
-  "author": "SOaC Framework"
+  "author": "SOaC Framework",
+  "difficulty_label": "Advanced"
 }

--- a/packages/007_identity_led_intrusion_defense/manifest.json
+++ b/packages/007_identity_led_intrusion_defense/manifest.json
@@ -14,7 +14,10 @@
     "exploit-chaining",
     "defense",
     "web-shell",
-    "lateral-movement"
+    "lateral-movement",
+    "red_team",
+    "blue_team",
+    "soc_manager"
   ],
   "threat_actor": "",
   "github_path": "packages/007_identity_led_intrusion_defense",
@@ -49,41 +52,56 @@
   "simulation_steps": [
     {
       "step_index": 1,
-      "role": "Red Team",
       "title": "Exploit Perimeter Vulnerability",
-      "technique": [
+      "description": "",
+      "role": "red_team",
+      "phase": "Initial Access",
+      "pillar": "Offense",
+      "mitre_techniques": [
         "T1190"
       ]
     },
     {
       "step_index": 2,
-      "role": "Red Team",
       "title": "Deploy Web Shell",
-      "technique": [
+      "description": "",
+      "role": "red_team",
+      "phase": "Persistence",
+      "pillar": "Offense",
+      "mitre_techniques": [
         "T1505.003"
       ]
     },
     {
       "step_index": 3,
-      "role": "Red Team",
       "title": "Escalate to SYSTEM via Kernel Exploit",
-      "technique": [
+      "description": "",
+      "role": "red_team",
+      "phase": "Privilege Escalation",
+      "pillar": "Offense",
+      "mitre_techniques": [
         "T1068"
       ]
     },
     {
       "step_index": 4,
-      "role": "Red Team",
       "title": "Move Laterally via RDP/SMB",
-      "technique": [
+      "description": "",
+      "role": "soc_team",
+      "phase": "Lateral Movement",
+      "pillar": "Respond",
+      "mitre_techniques": [
         "T1021"
       ]
     },
     {
       "step_index": 5,
-      "role": "Red Team",
       "title": "Pivot to Cloud Identity",
-      "technique": [
+      "description": "",
+      "role": "red_team",
+      "phase": "Initial Access",
+      "pillar": "Offense",
+      "mitre_techniques": [
         "T1078",
         "T1550"
       ]
@@ -100,5 +118,6 @@
   "created": "2026-03-28",
   "updated": "2026-03-28",
   "license": "Apache-2.0",
-  "author": "SOaC Community"
+  "author": "SOaC Community",
+  "difficulty_label": "Advanced"
 }

--- a/packages/008_cloud_control_plane_defense/manifest.json
+++ b/packages/008_cloud_control_plane_defense/manifest.json
@@ -15,7 +15,10 @@
     "defense",
     "federation",
     "serverless",
-    "cryptojacking"
+    "cryptojacking",
+    "red_team",
+    "blue_team",
+    "soc_manager"
   ],
   "threat_actor": null,
   "github_path": "packages/008_cloud_control_plane_defense",
@@ -48,27 +51,47 @@
   "simulation_steps": [
     {
       "step_index": 1,
-      "role": "Red Team",
       "title": "Service Principal Abuse",
-      "technique": []
+      "description": "",
+      "role": "red_team",
+      "phase": "Privilege Escalation",
+      "pillar": "Offense",
+      "mitre_techniques": [
+        "T1484.002"
+      ]
     },
     {
       "step_index": 2,
-      "role": "Red Team",
       "title": "Federation Tampering",
-      "technique": []
+      "description": "",
+      "role": "red_team",
+      "phase": "Persistence",
+      "pillar": "Offense",
+      "mitre_techniques": [
+        "T1525"
+      ]
     },
     {
       "step_index": 4,
-      "role": "Red Team",
       "title": "Lambda Backdoor",
-      "technique": []
+      "description": "",
+      "role": "ciso",
+      "phase": "Impact",
+      "pillar": "Govern",
+      "mitre_techniques": [
+        "T1496"
+      ]
     },
     {
       "step_index": 5,
-      "role": "Red Team",
       "title": "GPU Instance Launch",
-      "technique": []
+      "description": "",
+      "role": "red_team",
+      "phase": "Persistence",
+      "pillar": "Offense",
+      "mitre_techniques": [
+        "T1098.001"
+      ]
     }
   ],
   "lab_scenarios": [
@@ -82,5 +105,6 @@
   "created": "2025-03-28",
   "updated": "",
   "license": "MIT",
-  "author": "SOaC Framework"
+  "author": "SOaC Framework",
+  "difficulty_label": "Elite"
 }

--- a/packages/009_saas_oauth_abuse_extortion_defense/manifest.json
+++ b/packages/009_saas_oauth_abuse_extortion_defense/manifest.json
@@ -13,7 +13,10 @@
     "oauth",
     "extortion",
     "defense",
-    "data-theft"
+    "data-theft",
+    "red_team",
+    "blue_team",
+    "soc_manager"
   ],
   "threat_actor": null,
   "github_path": "packages/009_saas_oauth_abuse_extortion_defense",
@@ -50,33 +53,58 @@
   "simulation_steps": [
     {
       "step_index": 1,
-      "role": "Red Team",
       "title": "OAuth Token Compromise",
-      "technique": []
+      "description": "",
+      "role": "soc_team",
+      "phase": "Exfiltration",
+      "pillar": "Respond",
+      "mitre_techniques": [
+        "T1567.002"
+      ]
     },
     {
       "step_index": 2,
-      "role": "Red Team",
       "title": "SaaS Data Mapping",
-      "technique": []
+      "description": "",
+      "role": "blue_team",
+      "phase": "Discovery",
+      "pillar": "Detect",
+      "mitre_techniques": [
+        "T1213"
+      ]
     },
     {
       "step_index": 3,
-      "role": "Red Team",
       "title": "Bulk Data Staging",
-      "technique": []
+      "description": "",
+      "role": "blue_team",
+      "phase": "Discovery",
+      "pillar": "Detect",
+      "mitre_techniques": [
+        "T1657"
+      ]
     },
     {
       "step_index": 5,
-      "role": "Red Team",
       "title": "Anonymous Link Creation",
-      "technique": []
+      "description": "",
+      "role": "red_team",
+      "phase": "Persistence",
+      "pillar": "Offense",
+      "mitre_techniques": [
+        "T1098.003"
+      ]
     },
     {
       "step_index": 6,
-      "role": "Red Team",
       "title": "Ransom Communication",
-      "technique": []
+      "description": "",
+      "role": "blue_team",
+      "phase": "Collection",
+      "pillar": "Detect",
+      "mitre_techniques": [
+        "T1530"
+      ]
     }
   ],
   "lab_scenarios": [
@@ -90,5 +118,6 @@
   "created": "2025-03-28",
   "updated": "",
   "license": "MIT",
-  "author": "SOaC Framework"
+  "author": "SOaC Framework",
+  "difficulty_label": "Advanced"
 }

--- a/packages/010_callback_phishing_rmm_persistence_defense/manifest.json
+++ b/packages/010_callback_phishing_rmm_persistence_defense/manifest.json
@@ -14,7 +14,10 @@
     "persistence",
     "defense",
     "anydesk",
-    "screenconnect"
+    "screenconnect",
+    "red_team",
+    "blue_team",
+    "soc_manager"
   ],
   "threat_actor": null,
   "github_path": "packages/010_callback_phishing_rmm_persistence_defense",
@@ -46,33 +49,58 @@
   "simulation_steps": [
     {
       "step_index": 1,
-      "role": "Red Team",
       "title": "Callback Phishing Email",
-      "technique": []
+      "description": "",
+      "role": "red_team",
+      "phase": "Initial Access",
+      "pillar": "Offense",
+      "mitre_techniques": [
+        "T1566.003"
+      ]
     },
     {
       "step_index": 2,
-      "role": "Red Team",
       "title": "Phone Social Engineering",
-      "technique": []
+      "description": "",
+      "role": "soc_team",
+      "phase": "Lateral Movement",
+      "pillar": "Respond",
+      "mitre_techniques": [
+        "T1219"
+      ]
     },
     {
       "step_index": 3,
-      "role": "Red Team",
       "title": "RMM Tool Installation",
-      "technique": []
+      "description": "",
+      "role": "red_team",
+      "phase": "Persistence",
+      "pillar": "Offense",
+      "mitre_techniques": [
+        "T1543.003"
+      ]
     },
     {
       "step_index": 5,
-      "role": "Red Team",
       "title": "Service Installation",
-      "technique": []
+      "description": "",
+      "role": "red_team",
+      "phase": "Execution",
+      "pillar": "Offense",
+      "mitre_techniques": [
+        "T1053.005"
+      ]
     },
     {
       "step_index": 6,
-      "role": "Red Team",
       "title": "Remote Access Channel",
-      "technique": []
+      "description": "",
+      "role": "red_team",
+      "phase": "Initial Access",
+      "pillar": "Offense",
+      "mitre_techniques": [
+        "T1204.001"
+      ]
     }
   ],
   "lab_scenarios": [
@@ -86,5 +114,6 @@
   "created": "2025-03-28",
   "updated": "",
   "license": "MIT",
-  "author": "SOaC Framework"
+  "author": "SOaC Framework",
+  "difficulty_label": "Advanced"
 }

--- a/packages/011_genai_llm_abuse_defense/manifest.json
+++ b/packages/011_genai_llm_abuse_defense/manifest.json
@@ -14,7 +14,10 @@
     "data-exfiltration",
     "model-supply-chain",
     "owasp-llm",
-    "gtr-2025"
+    "gtr-2025",
+    "red_team",
+    "blue_team",
+    "soc_manager"
   ],
   "threat_actor": "Multiple (SCATTERED SPIDER, FAMOUS CHOLLIMA)",
   "github_path": "packages/011_genai_llm_abuse_defense",
@@ -45,49 +48,67 @@
   "simulation_steps": [
     {
       "step_index": 1,
-      "role": "Red Team",
       "title": "Enumerate AI Endpoints",
-      "technique": [
+      "description": "",
+      "role": "red_team",
+      "phase": "Execution",
+      "pillar": "Offense",
+      "mitre_techniques": [
         "T1595.002"
       ]
     },
     {
       "step_index": 2,
-      "role": "Red Team",
       "title": "DAN Jailbreak Prompt Injection",
-      "technique": [
+      "description": "",
+      "role": "red_team",
+      "phase": "Initial Access",
+      "pillar": "Offense",
+      "mitre_techniques": [
         "T1190"
       ]
     },
     {
       "step_index": 4,
-      "role": "Red Team",
       "title": "Extract Credentials via Crafted Queries",
-      "technique": [
+      "description": "",
+      "role": "soc_team",
+      "phase": "Exfiltration",
+      "pillar": "Respond",
+      "mitre_techniques": [
         "T1041"
       ]
     },
     {
       "step_index": 6,
-      "role": "Red Team",
       "title": "Distribute Backdoored Model on Hugging Face",
-      "technique": [
+      "description": "",
+      "role": "red_team",
+      "phase": "Initial Access",
+      "pillar": "Offense",
+      "mitre_techniques": [
         "T1195.002"
       ]
     },
     {
       "step_index": 7,
-      "role": "Victim",
       "title": "Data Scientist Downloads Poisoned Model",
-      "technique": [
+      "description": "",
+      "role": "red_team",
+      "phase": "Initial Access",
+      "pillar": "Offense",
+      "mitre_techniques": [
         "T1195.002"
       ]
     },
     {
       "step_index": 9,
-      "role": "Red Team",
       "title": "LLMjacking - Massive Unauthorized Inference",
-      "technique": [
+      "description": "",
+      "role": "ciso",
+      "phase": "Impact",
+      "pillar": "Govern",
+      "mitre_techniques": [
         "T1496"
       ]
     }
@@ -103,5 +124,6 @@
   "created": "2025-03-15",
   "updated": "2025-03-28",
   "license": "MIT",
-  "author": "SOaC Framework"
+  "author": "SOaC Framework",
+  "difficulty_label": "Advanced"
 }

--- a/packages/012_litellm_supply_chain_defense/manifest.json
+++ b/packages/012_litellm_supply_chain_defense/manifest.json
@@ -13,7 +13,10 @@
     "credential-theft",
     "defense",
     "python",
-    "ci-cd"
+    "ci-cd",
+    "red_team",
+    "blue_team",
+    "soc_manager"
   ],
   "threat_actor": "Shai-Hulud",
   "github_path": "packages/012_litellm_supply_chain_defense",
@@ -56,41 +59,56 @@
   "simulation_steps": [
     {
       "step_index": 1,
-      "role": "Red Team",
       "title": "Publish Trojanized LiteLLM Package",
-      "technique": [
+      "description": "",
+      "role": "red_team",
+      "phase": "Initial Access",
+      "pillar": "Offense",
+      "mitre_techniques": [
         "T1195.002"
       ]
     },
     {
       "step_index": 2,
-      "role": "Red Team",
       "title": "Deploy .pth File Persistence",
-      "technique": [
+      "description": "",
+      "role": "red_team",
+      "phase": "Persistence",
+      "pillar": "Offense",
+      "mitre_techniques": [
         "T1546.016"
       ]
     },
     {
       "step_index": 3,
-      "role": "Red Team",
       "title": "Harvest Cloud Credentials from Environment",
-      "technique": [
+      "description": "",
+      "role": "blue_team",
+      "phase": "Credential Access",
+      "pillar": "Detect",
+      "mitre_techniques": [
         "T1552.001"
       ]
     },
     {
       "step_index": 4,
-      "role": "Red Team",
       "title": "Steal OAuth Tokens from Running Sessions",
-      "technique": [
+      "description": "",
+      "role": "blue_team",
+      "phase": "Credential Access",
+      "pillar": "Detect",
+      "mitre_techniques": [
         "T1528"
       ]
     },
     {
       "step_index": 5,
-      "role": "Red Team",
       "title": "Exfiltrate Credentials to C2 Infrastructure",
-      "technique": [
+      "description": "",
+      "role": "soc_team",
+      "phase": "Exfiltration",
+      "pillar": "Respond",
+      "mitre_techniques": [
         "T1567",
         "T1071.001"
       ]
@@ -104,5 +122,6 @@
       "type": "full",
       "estimated_minutes": 45
     }
-  ]
+  ],
+  "difficulty_label": "Elite"
 }

--- a/packages/013_ci_cd_supply_chain_defense/manifest.json
+++ b/packages/013_ci_cd_supply_chain_defense/manifest.json
@@ -50,50 +50,90 @@
     {
       "step_index": 1,
       "title": "Steal CI/CD service account token via misconfiguration or prior compromise",
+      "description": "Action: Steal CI/CD service account token via misconfiguration or prior compromise",
       "role": "red_team",
-      "description": "Action: Steal CI/CD service account token via misconfiguration or prior compromise"
+      "phase": "Initial Access",
+      "pillar": "Offense",
+      "mitre_techniques": [
+        "T1195.002"
+      ]
     },
     {
       "step_index": 2,
       "title": "Access release automation environment or workflow repository",
-      "role": "red_team",
-      "description": "Action: Access release automation environment or workflow repository"
+      "description": "Action: Access release automation environment or workflow repository",
+      "role": "blue_team",
+      "phase": "Credential Access",
+      "pillar": "Detect",
+      "mitre_techniques": [
+        "T1552.001"
+      ]
     },
     {
       "step_index": 3,
       "title": "Force-push malicious code to trusted version tags",
-      "role": "red_team",
-      "description": "Action: Force-push malicious code to trusted version tags"
+      "description": "Action: Force-push malicious code to trusted version tags",
+      "role": "blue_team",
+      "phase": "Credential Access",
+      "pillar": "Detect",
+      "mitre_techniques": [
+        "T1552.004"
+      ]
     },
     {
       "step_index": 4,
       "title": "Poison downstream builds that consume mutated tags",
+      "description": "Action: Poison downstream builds that consume mutated tags",
       "role": "red_team",
-      "description": "Action: Poison downstream builds that consume mutated tags"
+      "phase": "Initial Access",
+      "pillar": "Offense",
+      "mitre_techniques": [
+        "T1078.004"
+      ]
     },
     {
       "step_index": 5,
       "title": "Harvest secrets from runner filesystem and environment variables",
-      "role": "red_team",
-      "description": "Action: Harvest secrets from runner filesystem and environment variables"
+      "description": "Action: Harvest secrets from runner filesystem and environment variables",
+      "role": "soc_team",
+      "phase": "Exfiltration",
+      "pillar": "Respond",
+      "mitre_techniques": [
+        "T1567.001"
+      ]
     },
     {
       "step_index": 6,
       "title": "Attempt cloud pivot using exposed credentials or tokens",
-      "role": "red_team",
-      "description": "Action: Attempt cloud pivot using exposed credentials or tokens"
+      "description": "Action: Attempt cloud pivot using exposed credentials or tokens",
+      "role": "blue_team",
+      "phase": "Credential Access",
+      "pillar": "Detect",
+      "mitre_techniques": [
+        "T1528"
+      ]
     },
     {
       "step_index": 7,
       "title": "Stage or exfiltrate data to attacker-controlled repo or network endpoint",
+      "description": "Action: Stage or exfiltrate data to attacker-controlled repo or network endpoint",
       "role": "red_team",
-      "description": "Action: Stage or exfiltrate data to attacker-controlled repo or network endpoint"
+      "phase": "Defense Evasion",
+      "pillar": "Offense",
+      "mitre_techniques": [
+        "T1550.001"
+      ]
     },
     {
       "step_index": 8,
       "title": "Trigger recovery, secret rotation, artifact validation, and incident escalation",
-      "role": "blue_team",
-      "description": "Action: Trigger recovery, secret rotation, artifact validation, and incident escalation"
+      "description": "Action: Trigger recovery, secret rotation, artifact validation, and incident escalation",
+      "role": "red_team",
+      "phase": "Initial Access",
+      "pillar": "Offense",
+      "mitre_techniques": [
+        "T1195.002"
+      ]
     }
   ],
   "linkedin_cta": "TRIVY",


### PR DESCRIPTION
### Changes
- Every simulation_step now has: `phase`, `pillar`, `role`, `mitre_techniques`
- Deterministic mapping: MITRE technique → ATT&CK tactic (phase) → SOaC pillar → team role
- No more heuristic-based role assignment
- All 13 packages updated
- Added `difficulty_label` and role tags where missing

### Canonical Step Model v2.1
```json
{
  "step_index": 1,
  "title": "...",
  "description": "...",
  "role": "red_team|blue_team|soc_team|ciso",
  "phase": "Initial Access|Execution|...",
  "pillar": "Offense|Detect|Respond|Govern",
  "mitre_techniques": ["T1195.002"]
}
```