### PR TITLE
ci: upgrade GitHub Actions Node.js 18→24

### DIFF
--- a/.github/workflows/soac-drift-detection.yml
+++ b/.github/workflows/soac-drift-detection.yml
@@ -22,10 +22,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup Node.js 18
+      - name: Setup Node.js 24
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 24
 
       - name: Run drift detection
         id: drift

--- a/.github/workflows/soac-validation.yml
+++ b/.github/workflows/soac-validation.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '24'
       - name: Install dependencies
         run: npm install
         working-directory: tools/soac-harness


### PR DESCRIPTION
Upgrades Node.js version in CI workflows from 18 to 24.

- `soac-validation.yml`: node-version 18→24
- `soac-drift-detection.yml`: node-version 18→24

Motivation: GitHub Actions deprecation of Node.js 16/18/20 runners by June 2026.